### PR TITLE
Fortran code style

### DIFF
--- a/MIM.f90
+++ b/MIM.f90
@@ -202,14 +202,13 @@ program MIM
   read(8, nml=GRID)
   read(8, nml=INITIAL_CONDITONS)
   read(8, nml=EXTERNAL_FORCING)
-  close (unit = 8)
-
+  close(unit=8)
 
   nwrite = int(dumpFreq/dt)
   avwrite = int(avFreq/dt)
 
   ! Pi, the constant
-  pi=3.1415926535897932384
+  pi = 3.1415926535897932384
   ! Zero vector - for internal use only
   zeros = 0d0
 
@@ -316,32 +315,32 @@ program MIM
   if (.not. RedGrav) then
     ! Initialise arrays for pressure solver
     ! a = derivatives of the depth field
-    do j=1, ny
-      do i=1, nx
-        a(1,i,j)=g_vec(1)*0.5*(depth(i+1,j)+depth(i,j))/dx**2
-        a(2,i,j)=g_vec(1)*0.5*(depth(i,j+1)+depth(i,j))/dy**2
-        a(3,i,j)=g_vec(1)*0.5*(depth(i,j)+depth(i-1,j))/dx**2
-        a(4,i,j)=g_vec(1)*0.5*(depth(i,j)+depth(i,j-1))/dy**2
+    do j = 1, ny
+      do i = 1, nx
+        a(1,i,j) = g_vec(1)*0.5*(depth(i+1,j)+depth(i,j))/dx**2
+        a(2,i,j) = g_vec(1)*0.5*(depth(i,j+1)+depth(i,j))/dy**2
+        a(3,i,j) = g_vec(1)*0.5*(depth(i,j)+depth(i-1,j))/dx**2
+        a(4,i,j) = g_vec(1)*0.5*(depth(i,j)+depth(i,j-1))/dy**2
       end do
     end do
-    do j=1, ny
-      a(1, nx, j)=0.0
-      a(3, 1, j)=0.0
+    do j = 1, ny
+      a(1, nx, j) = 0.0
+      a(3, 1, j) = 0.0
     end do
-    do i=1, nx
-      a(2, i, ny)=0.0
-      a(4, i, 1)=0.0
+    do i = 1, nx
+      a(2, i, ny) = 0.0
+      a(4, i, 1) = 0.0
     end do
-    do j=1, ny
-      do i=1, nx
-        a(5,i,j)=-a(1,i,j)-a(2,i,j)-a(3,i,j)-a(4,i,j)
+    do j = 1, ny
+      do i = 1, nx
+        a(5,i,j) = -a(1,i,j)-a(2,i,j)-a(3,i,j)-a(4,i,j)
       end do
     end do
 
     ! Calculate the spectral radius of the grid for use by the
     ! successive over-relaxation scheme
-    rjac=(cos(pi/real(nx))*dy**2+cos(pi/real(ny))*dx**2) &
-         /(dx**2+dy**2)
+    rjac = (cos(pi/real(nx))*dy**2+cos(pi/real(ny))*dx**2) &
+           /(dx**2+dy**2)
     ! If peridodic boundary conditions are ever implemented, then pi ->
     ! 2*pi in this calculation
 
@@ -528,7 +527,7 @@ program MIM
   !!! MAIN LOOP OF THE MODEL STARTS HERE                                    !!!
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  do n=1, nTimeSteps
+  do n = 1, nTimeSteps
 
     ! Time varying winds
     if (UseSinusoidWind .eqv. .true.) then
@@ -574,9 +573,9 @@ program MIM
     ! Use dh/dt, du/dt and dv/dt to step h, u and v forward in time with
     ! the Adams-Bashforth third order linear multistep method
 
-    unew=u+dt*(23d0*dudt - 16d0*dudtold + 5d0*dudtveryold)/12d0
-    vnew=v+dt*(23d0*dvdt - 16d0*dvdtold + 5d0*dvdtveryold)/12d0
-    hnew=h+dt*(23d0*dhdt - 16d0*dhdtold + 5d0*dhdtveryold)/12d0
+    unew = u+dt*(23d0*dudt - 16d0*dudtold + 5d0*dudtveryold)/12d0
+    vnew = v+dt*(23d0*dvdt - 16d0*dvdtold + 5d0*dvdtveryold)/12d0
+    hnew = h+dt*(23d0*dhdt - 16d0*dhdtold + 5d0*dhdtveryold)/12d0
 
     ! Apply the boundary conditions
     ! - Enforce no normal flow boundary condition
@@ -668,8 +667,8 @@ program MIM
     counter = 0
 
     do k = 1, layers
-      do j=1, ny
-        do i=1, nx
+      do j = 1, ny
+        do i = 1, nx
           if (hnew(i, j, k) .lt. hmin) then
             hnew(i, j, k) = hmin
             counter = counter + 1
@@ -678,7 +677,7 @@ program MIM
               ! dropped below hmin and this line has been used.
               open(unit=10, file='layer thickness dropped below hmin.txt', &
                   action="write", status="unknown", &
-                  form="formatted", position = "append")
+                  form="formatted", position="append")
               write(10, 1111) n
 1111          format("layer thickness dropped below hmin at time step ", 1i10.10)
               close(unit=10)
@@ -734,31 +733,31 @@ program MIM
       write(num, '(i10.10)') n
 
       ! Output the data to a file
-      open(unit = 10, status='replace', file='output/snap.h.'//num, &
+      open(unit=10, status='replace', file='output/snap.h.'//num, &
           form='unformatted')
       write(10) h(1:nx, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace', file='output/snap.u.'//num, &
+      open(unit=10, status='replace', file='output/snap.u.'//num, &
           form='unformatted')
       write(10) u(1:nx+1, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace', file='output/snap.v.'//num, &
+      open(unit=10, status='replace', file='output/snap.v.'//num, &
           form='unformatted')
       write(10) v(1:nx, 1:ny+1, :)
       close(10)
       if (.not. RedGrav) then
-        open(unit = 10, status='replace', file='output/snap.eta.'//num, &
+        open(unit=10, status='replace', file='output/snap.eta.'//num, &
             form='unformatted')
         write(10) eta(1:nx, 1:ny)
         close(10)
       end if
 
       if (DumpWind .eqv. .true.) then
-        open(unit = 10, status='replace', file='output/wind_x.'//num, &
+        open(unit=10, status='replace', file='output/wind_x.'//num, &
             form='unformatted')
         write(10) wind_x(1:nx+1, 1:ny)
         close(10)
-        open(unit = 10, status='replace', file='output/wind_y.'//num, &
+        open(unit=10, status='replace', file='output/wind_y.'//num, &
             form='unformatted')
         write(10) wind_y(1:nx, 1:ny+1)
         close(10)
@@ -776,28 +775,28 @@ program MIM
       ! OK
     else if (mod(n-1, avwrite) .eq. 0) then
 
-      hav=hav/real(avwrite)
-      uav=uav/real(avwrite)
-      vav=vav/real(avwrite)
+      hav = hav/real(avwrite)
+      uav = uav/real(avwrite)
+      vav = vav/real(avwrite)
 
       write(num, '(i10.10)') n
 
       ! output the data to a file
 
-      open(unit = 10, status='replace', file='output/av.h.'//num, &
+      open(unit=10, status='replace', file='output/av.h.'//num, &
           form='unformatted')
       write(10) hav(1:nx, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace', file='output/av.u.'//num, &
+      open(unit=10, status='replace', file='output/av.u.'//num, &
           form='unformatted')
       write(10) uav(1:nx+1, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace', file='output/av.v.'//num, &
+      open(unit=10, status='replace', file='output/av.v.'//num, &
           form='unformatted')
       write(10) vav(1:nx, 1:ny+1, :)
       close(10)
       if (.not. RedGrav) then
-        open(unit = 10, status='replace', file='output/av.eta.'//num, &
+        open(unit=10, status='replace', file='output/av.eta.'//num, &
             form='unformatted')
         write(10) etaav(1:nx, 1:ny)
         close(10)
@@ -815,14 +814,14 @@ program MIM
       if (.not. RedGrav) then
         etaav = 0.0
       end if
-      ! h2av=0.0
+      ! h2av = 0.0
 
     end if
 
   end do
 
   open(unit=10, file='run_finished.txt', action="write", status="unknown", &
-      form="formatted", position = "append")
+      form="formatted", position="append")
   write(10, 1112) n
 1112 format( "run finished at time step ", 1i10.10)
   close(unit=10)
@@ -887,9 +886,9 @@ subroutine evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
 
   ! For the rest of the layers we get a baroclinic pressure contribution
   do k = 1, layers ! move through the different layers of the model
-    do j=1, ny ! move through longitude
-      do i=1, nx ! move through latitude
-        b(i,j,k)= M(i,j,k) + (u(i,j,k)**2+u(i+1,j,k)**2+v(i,j,k)**2+v(i,j+1,k)**2)/4.0d0
+    do j = 1, ny ! move through longitude
+      do i = 1, nx ! move through latitude
+        b(i,j,k) = M(i,j,k) + (u(i,j,k)**2+u(i+1,j,k)**2+v(i,j,k)**2+v(i,j+1,k)**2)/4.0d0
         ! Add the (u^2 + v^2)/2 term to the Montgomery Potential
       end do
     end do
@@ -916,8 +915,8 @@ subroutine evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, gr)
   b = 0d0
 
   do k = 1, layers ! move through the different layers of the model
-    do j=1, ny ! move through longitude
-      do i=1, nx ! move through latitude
+    do j = 1, ny ! move through longitude
+      do i = 1, nx ! move through latitude
         ! The following loops are to get the pressure term in the
         ! Bernoulli Potential
         b_proto = 0d0
@@ -933,7 +932,7 @@ subroutine evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, gr)
         end do
         ! Add the (u^2 + v^2)/2 term to the pressure componenet of the
         ! Bernoulli Potential
-        b(i,j,k)= b_proto + (u(i,j,k)**2+u(i+1,j,k)**2+v(i,j,k)**2+v(i,j+1,k)**2)/4.0d0
+        b(i,j,k) = b_proto + (u(i,j,k)**2+u(i+1,j,k)**2+v(i,j,k)**2+v(i,j+1,k)**2)/4.0d0
       end do
     end do
   end do
@@ -958,9 +957,9 @@ subroutine evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
   zeta = 0d0
 
   do k = 1, layers
-    do j=1, ny+1
-      do i=1, nx+1
-        zeta(i,j,k)=(v(i,j,k)-v(i-1,j,k))/dx-(u(i,j,k)-u(i,j-1,k))/dy
+    do j = 1, ny+1
+      do i = 1, nx+1
+        zeta(i,j,k) = (v(i,j,k)-v(i-1,j,k))/dx-(u(i,j,k)-u(i,j-1,k))/dy
       end do
     end do
   end do
@@ -999,8 +998,8 @@ subroutine evaluate_dhdt(dhdt, h, u, v, ah, dx, dy, nx, ny, layers, &
   ! Loop through all layers except lowest and calculate
   ! thickness tendency due to diffusive mass fluxes
   do k = 1, layers-1
-    do j=1, ny
-      do i=1, nx
+    do j = 1, ny
+      do i = 1, nx
         dhdt_GM(i,j,k) = &
             ah(k)*(h(i+1,j,k)*wetmask(i+1,j)    &
               + (1d0 - wetmask(i+1,j))*h(i,j,k) & ! reflect around boundary
@@ -1022,8 +1021,8 @@ subroutine evaluate_dhdt(dhdt, h, u, v, ah, dx, dy, nx, ny, layers, &
   ! using n-layer physics it is constrained to balance the layers
   ! above it.
   if (RedGrav) then
-    do j=1, ny
-      do i=1, nx
+    do j = 1, ny
+      do i = 1, nx
         dhdt_GM(i,j,layers) = &
             ah(layers)*(h(i+1,j,layers)*wetmask(i+1,j)   &
               + (1d0 - wetmask(i+1,j))*h(i,j,layers)     & ! boundary
@@ -1049,8 +1048,8 @@ subroutine evaluate_dhdt(dhdt, h, u, v, ah, dx, dy, nx, ny, layers, &
   dhdt = 0d0
 
   do k = 1, layers
-    do j=1, ny
-      do i=1, nx
+    do j = 1, ny
+      do i = 1, nx
         dhdt(i,j,k) = &
             dhdt_GM(i,j,k) & ! horizontal thickness diffusion
             - ((h(i,j,k)+h(i+1,j,k))*u(i+1,j,k) &
@@ -1103,8 +1102,8 @@ subroutine evaluate_dudt(dudt, h, u, v, b, zeta, wind_x, fu, &
   dudt = 0d0
 
   do k = 1, layers
-    do i=1, nx
-      do j=1, ny
+    do i = 1, nx
+      do j = 1, ny
         dudt(i,j,k) = au*(u(i+1,j,k)+u(i-1,j,k)-2.0d0*u(i,j,k))/(dx*dx) & ! x-component
             + au*(u(i,j+1,k)+u(i,j-1,k)-2.0d0*u(i,j,k) &
               ! boundary conditions
@@ -1174,8 +1173,8 @@ subroutine evaluate_dvdt(dvdt, h, u, v, b, zeta, wind_y, fv, &
   dvdt = 0d0
 
   do k = 1, layers
-    do j=1, ny
-      do i=1, nx
+    do j = 1, ny
+      do i = 1, nx
         dvdt(i,j,k) = &
             au*(v(i+1,j,k)+v(i-1,j,k)-2.0d0*v(i,j,k) &
               ! boundary conditions
@@ -1335,7 +1334,7 @@ subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, rjac, eps, ma
   ! first guess for etanew
   etanew = etastar
 
-  relax_param=1.d0 ! successive over-relaxation parameter
+  relax_param = 1.d0 ! successive over-relaxation parameter
 
   ! Calculate initial residual, so that we can stop the loop when the
   ! current residual = norm0*eps
@@ -1359,9 +1358,9 @@ subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, rjac, eps, ma
 
   do nit = 1, maxits
     ! norm_old = norm
-    norm=0.d0
-    do i=1, nx
-      do j=1, ny
+    norm = 0.d0
+    do i = 1, nx
+      do j = 1, ny
         res(i,j) = &
             a(1,i,j)*etanew(i+1,j) &
             + a(2,i,j)*etanew(i,j+1) &
@@ -1371,13 +1370,13 @@ subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, rjac, eps, ma
             - freesurfFac*etanew(i,j)/dt**2 &
             - rhs(i,j)
         norm = norm + abs(res(i,j))
-        etanew(i,j)=etanew(i,j)-relax_param*res(i,j)/(a(5,i,j))
+        etanew(i,j) = etanew(i,j)-relax_param*res(i,j)/(a(5,i,j))
       end do
     end do
     if (nit.eq.1) then
-      relax_param=1.d0/(1.d0-0.5d0*rjac**2)
+      relax_param = 1.d0/(1.d0-0.5d0*rjac**2)
     else
-      relax_param=1.d0/(1.d0-0.25d0*rjac**2*relax_param)
+      relax_param = 1.d0/(1.d0-0.25d0*rjac**2*relax_param)
     end if
 
     call wrap_fields_2D(etanew, nx, ny)
@@ -1409,9 +1408,9 @@ subroutine break_if_NaN(data, nx, ny, layers, n)
   integer nx, ny, layers, n, i, j, k
   double precision data(0:nx+1, 0:ny+1, layers)
 
-  do k=1, layers
-    do j=1, ny
-      do i=1, nx
+  do k = 1, layers
+    do j = 1, ny
+      do i = 1, nx
         if (data(i,j,k) .ne. data(i,j,k)) then
           ! write a file saying so
           open(unit=10, file='NaN detected.txt', action="write", &
@@ -1544,7 +1543,7 @@ subroutine read_input_fileH(name, array, default, nx, ny, layers)
   double precision array_small(nx, ny, layers)
 
   if (name.ne.'') then
-    open(unit = 10, form='unformatted', file=name)
+    open(unit=10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
@@ -1574,7 +1573,7 @@ subroutine read_input_fileH_2D(name, array, default, nx, ny)
   double precision array_small(nx, ny)
 
   if (name.ne.'') then
-    open(unit = 10, form='unformatted', file=name)
+    open(unit=10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
@@ -1602,7 +1601,7 @@ subroutine read_input_fileU(name, array, default, nx, ny, layers)
   double precision array_small(nx+1, ny, layers)
 
   if (name.ne.'') then
-    open(unit = 10, form='unformatted', file=name)
+    open(unit=10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
@@ -1630,7 +1629,7 @@ subroutine read_input_fileV(name, array, default, nx, ny, layers)
   double precision array_small(nx, ny+1, layers)
 
   if (name.ne.'') then
-    open(unit = 10, form='unformatted', file=name)
+    open(unit=10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
@@ -1702,7 +1701,7 @@ subroutine ranseed()
   allocate(a_seed(1:i_seed))
   call random_seed(get=a_seed)
   call date_and_time(values=dt_seed)
-  a_seed(i_seed)=dt_seed(8); a_seed(1)=dt_seed(8)*dt_seed(7)*dt_seed(6)
+  a_seed(i_seed) = dt_seed(8); a_seed(1) = dt_seed(8)*dt_seed(7)*dt_seed(6)
   call random_seed(put=a_seed)
   return
 end subroutine ranseed

--- a/MIM.f90
+++ b/MIM.f90
@@ -528,7 +528,7 @@ program MIM
   !!! MAIN LOOP OF THE MODEL STARTS HERE                                    !!!
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  do 9999 n=1,nTimeSteps
+  do n=1,nTimeSteps
 
     ! Time varying winds
     if (UseSinusoidWind .eqv. .TRUE.) then
@@ -819,7 +819,7 @@ program MIM
 
 120 endif
 
-9999 continue
+  end do
 
     OPEN(UNIT=10, FILE='run_finished.txt', ACTION="write", STATUS="unknown", &
         FORM="formatted", POSITION = "append")

--- a/MIM.f90
+++ b/MIM.f90
@@ -37,83 +37,83 @@ program MIM
   integer, parameter :: layers = 2 !< number of active layers in the model
 
   ! Layer thickness (h)
-  double precision :: h(0:nx+1,0:ny+1,layers)
-  double precision :: dhdt(0:nx+1,0:ny+1,layers)
-  double precision :: dhdtold(0:nx+1,0:ny+1,layers)
-  double precision :: dhdtveryold(0:nx+1,0:ny+1,layers)
-  double precision :: hnew(0:nx+1,0:ny+1,layers)
+  double precision :: h(0:nx+1, 0:ny+1, layers)
+  double precision :: dhdt(0:nx+1, 0:ny+1, layers)
+  double precision :: dhdtold(0:nx+1, 0:ny+1, layers)
+  double precision :: dhdtveryold(0:nx+1, 0:ny+1, layers)
+  double precision :: hnew(0:nx+1, 0:ny+1, layers)
   ! for initialisation
-  double precision :: hhalf(0:nx+1,0:ny+1,layers)
+  double precision :: hhalf(0:nx+1, 0:ny+1, layers)
   ! for saving average fields
-  double precision :: hav(0:nx+1,0:ny+1,layers)
+  double precision :: hav(0:nx+1, 0:ny+1, layers)
 
   ! Velocity component u
-  double precision :: u(0:nx+1,0:ny+1,layers)
-  double precision :: dudt(0:nx+1,0:ny+1,layers)
-  double precision :: dudtold(0:nx+1,0:ny+1,layers)
-  double precision :: dudtveryold(0:nx+1,0:ny+1,layers)
-  double precision :: unew(0:nx+1,0:ny+1,layers)
-  double precision :: dudt_bt(0:nx+1,0:ny+1)
+  double precision :: u(0:nx+1, 0:ny+1, layers)
+  double precision :: dudt(0:nx+1, 0:ny+1, layers)
+  double precision :: dudtold(0:nx+1, 0:ny+1, layers)
+  double precision :: dudtveryold(0:nx+1, 0:ny+1, layers)
+  double precision :: unew(0:nx+1, 0:ny+1, layers)
+  double precision :: dudt_bt(0:nx+1, 0:ny+1)
   ! barotropic velocity components (for pressure solver)
-  double precision :: ub(0:nx+1,0:ny+1)
+  double precision :: ub(0:nx+1, 0:ny+1)
   ! for initialisation
-  double precision :: uhalf(0:nx+1,0:ny+1,layers)
+  double precision :: uhalf(0:nx+1, 0:ny+1, layers)
   ! for saving average fields
-  double precision :: uav(0:nx+1,0:ny+1,layers)
+  double precision :: uav(0:nx+1, 0:ny+1, layers)
 
   ! Velocity component v
-  double precision :: v(0:nx+1,0:ny+1,layers)
-  double precision :: dvdt(0:nx+1,0:ny+1,layers)
-  double precision :: dvdtold(0:nx+1,0:ny+1,layers)
-  double precision :: dvdtveryold(0:nx+1,0:ny+1,layers)
-  double precision :: vnew(0:nx+1,0:ny+1,layers)
-  double precision :: dvdt_bt(nx+1,ny)
+  double precision :: v(0:nx+1, 0:ny+1, layers)
+  double precision :: dvdt(0:nx+1, 0:ny+1, layers)
+  double precision :: dvdtold(0:nx+1, 0:ny+1, layers)
+  double precision :: dvdtveryold(0:nx+1, 0:ny+1, layers)
+  double precision :: vnew(0:nx+1, 0:ny+1, layers)
+  double precision :: dvdt_bt(nx+1, ny)
   ! barotropic velocity components (for pressure solver)
-  double precision :: vb(nx+1,ny)
+  double precision :: vb(nx+1, ny)
   ! for initialisation
-  double precision :: vhalf(0:nx+1,0:ny+1,layers)
+  double precision :: vhalf(0:nx+1, 0:ny+1, layers)
   ! for saving average fields
-  double precision :: vav(0:nx+1,0:ny+1,layers)
+  double precision :: vav(0:nx+1, 0:ny+1, layers)
 
   ! Free surface (eta)
-  double precision :: eta(0:nx+1,0:ny+1)
-  double precision :: etastar(0:nx+1,0:ny+1)
-  double precision :: etanew(0:nx+1,0:ny+1)
+  double precision :: eta(0:nx+1, 0:ny+1)
+  double precision :: etastar(0:nx+1, 0:ny+1)
+  double precision :: etanew(0:nx+1, 0:ny+1)
   ! for saving average fields
-  double precision :: etaav(0:nx+1,0:ny+1)
+  double precision :: etaav(0:nx+1, 0:ny+1)
 
   ! Bathymetry
   character(30) :: depthFile
-  double precision :: depth(0:nx+1,0:ny+1)
+  double precision :: depth(0:nx+1, 0:ny+1)
   double precision :: H0 ! default depth in no file specified
   ! Pressure solver variables
-  double precision :: a(5,nx,ny)
-  double precision :: phi(0:nx+1,0:ny+1), phiold(0:nx+1,0:ny+1)
+  double precision :: a(5, nx, ny)
+  double precision :: phi(0:nx+1, 0:ny+1), phiold(0:nx+1, 0:ny+1)
 
   ! Bernoulli potential and relative vorticity
-  double precision :: b(0:nx+1,0:ny+1,layers)
-  double precision :: zeta(0:nx+1,0:ny+1,layers)
+  double precision :: b(0:nx+1, 0:ny+1, layers)
+  double precision :: zeta(0:nx+1, 0:ny+1, layers)
 
 
   ! Grid
   double precision :: dx, dy
   double precision :: x_u(0:nx), y_u(0:ny)
   double precision :: x_v(0:nx), y_v(0:ny)
-  double precision :: wetmask(0:nx+1,0:ny+1)
-  double precision :: hfacW(0:nx+1,0:ny+1)
-  double precision :: hfacE(0:nx+1,0:ny+1)
-  double precision :: hfacN(0:nx+1,0:ny+1)
-  double precision :: hfacS(0:nx+1,0:ny+1)
+  double precision :: wetmask(0:nx+1, 0:ny+1)
+  double precision :: hfacW(0:nx+1, 0:ny+1)
+  double precision :: hfacE(0:nx+1, 0:ny+1)
+  double precision :: hfacN(0:nx+1, 0:ny+1)
+  double precision :: hfacS(0:nx+1, 0:ny+1)
   ! Coriolis parameter at u and v grid-points respectively
-  double precision :: fu(0:nx+1,0:ny+1)
-  double precision :: fv(0:nx+1,0:ny+1)
+  double precision :: fu(0:nx+1, 0:ny+1)
+  double precision :: fv(0:nx+1, 0:ny+1)
   ! File names to read them from
   character(30) :: fUfile, fVfile
   character(30) :: wetMaskFile
 
   ! Numerics
   double precision :: pi, dt
-  double precision :: au,ah(layers),ar, botDrag
+  double precision :: au, ah(layers), ar, botDrag
   double precision :: slip
   double precision :: hmin
   integer nTimeSteps
@@ -124,7 +124,7 @@ program MIM
   integer maxits
   double precision :: eps, rjac
   double precision :: freesurfFac
-  double precision :: h_norming(0:nx+1,0:ny+1)
+  double precision :: h_norming(0:nx+1, 0:ny+1)
 
   ! Model
   double precision :: hmean(layers)
@@ -132,7 +132,7 @@ program MIM
   logical :: RedGrav
 
   ! Loop variables
-  integer :: i,j,k,n
+  integer :: i, j, k, n
 
   ! Character variable for numbering the outputs
   character(10) :: num
@@ -142,10 +142,10 @@ program MIM
   double precision :: g_vec(layers), rho0
 
   ! Wind
-  double precision :: wind_x(0:nx+1,0:ny+1)
-  double precision :: wind_y(0:nx+1,0:ny+1)
-  double precision :: base_wind_x(0:nx+1,0:ny+1)
-  double precision :: base_wind_y(0:nx+1,0:ny+1)
+  double precision :: wind_x(0:nx+1, 0:ny+1)
+  double precision :: wind_y(0:nx+1, 0:ny+1)
+  double precision :: base_wind_x(0:nx+1, 0:ny+1)
+  double precision :: base_wind_y(0:nx+1, 0:ny+1)
   logical :: UseSinusoidWind
   logical :: UseStochWind
   logical :: DumpWind
@@ -154,12 +154,12 @@ program MIM
   double precision :: stoch_wind_mag
 
   ! Sponge
-  double precision :: spongeHTimeScale(0:nx+1,0:ny+1,layers)
-  double precision :: spongeUTimeScale(0:nx+1,0:ny+1,layers)
-  double precision :: spongeVTimeScale(0:nx+1,0:ny+1,layers)
-  double precision :: spongeH(0:nx+1,0:ny+1,layers)
-  double precision :: spongeU(0:nx+1,0:ny+1,layers)
-  double precision :: spongeV(0:nx+1,0:ny+1,layers)
+  double precision :: spongeHTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision :: spongeUTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision :: spongeVTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision :: spongeH(0:nx+1, 0:ny+1, layers)
+  double precision :: spongeU(0:nx+1, 0:ny+1, layers)
+  double precision :: spongeV(0:nx+1, 0:ny+1, layers)
   character(30) :: spongeHTimeScaleFile
   character(30) :: spongeUTimeScaleFile
   character(30) :: spongeVTimeScaleFile
@@ -168,40 +168,40 @@ program MIM
   character(30) :: spongeVfile
 
   ! Input files
-  character(30) :: initUfile,initVfile,initHfile,initEtaFile
-  character(30) :: zonalWindFile,meridionalWindFile
+  character(30) :: initUfile, initVfile, initHfile, initEtaFile
+  character(30) :: zonalWindFile, meridionalWindFile
 
   ! Set default values here
 
   ! TODO Possibly wait until the model is split into multiple files,
   ! then hide the long unsightly code there.
 
-  NAMELIST /NUMERICS/ au,ah,ar,botDrag,dt,slip,nTimeSteps, &
-      dumpFreq,avFreq,hmin, maxits, freesurfFac, eps
+  NAMELIST /NUMERICS/ au, ah, ar, botDrag, dt, slip, nTimeSteps, &
+      dumpFreq, avFreq, hmin, maxits, freesurfFac, eps
 
   NAMELIST /MODEL/ hmean, depthFile, H0, RedGrav
 
-  NAMELIST /SPONGE/ spongeHTimeScaleFile,spongeUTimeScaleFile, &
-      spongeVTimeScaleFile,spongeHfile,spongeUfile,spongeVfile
+  NAMELIST /SPONGE/ spongeHTimeScaleFile, spongeUTimeScaleFile, &
+      spongeVTimeScaleFile, spongeHfile, spongeUfile, spongeVfile
 
   NAMELIST /PHYSICS/ g_vec, rho0
 
   NAMELIST /GRID/ dx, dy, fUfile, fVfile, wetMaskFile
 
-  NAMELIST /INITIAL_CONDITONS/ initUfile,initVfile,initHfile,initEtaFile
+  NAMELIST /INITIAL_CONDITONS/ initUfile, initVfile, initHfile, initEtaFile
 
-  NAMELIST /EXTERNAL_FORCING/ zonalWindFile,meridionalWindFile, &
+  NAMELIST /EXTERNAL_FORCING/ zonalWindFile, meridionalWindFile, &
       UseSinusoidWind, UseStochWind, wind_alpha, wind_beta, &
       wind_period, wind_t_offset, DumpWind
 
-  open(unit=8,file="parameters.in", status='OLD', recl=80)
-  read(unit=8,nml=NUMERICS)
-  read(unit=8,nml=MODEL)
-  read(unit=8,nml=SPONGE)
-  read(8,nml=PHYSICS)
-  read(8,nml=GRID)
-  read(8,nml=INITIAL_CONDITONS)
-  read(8,nml=EXTERNAL_FORCING)
+  open(unit=8, file="parameters.in", status='OLD', recl=80)
+  read(unit=8, nml=NUMERICS)
+  read(unit=8, nml=MODEL)
+  read(unit=8, nml=SPONGE)
+  read(8, nml=PHYSICS)
+  read(8, nml=GRID)
+  read(8, nml=INITIAL_CONDITONS)
+  read(8, nml=EXTERNAL_FORCING)
   close (unit = 8)
 
 
@@ -219,7 +219,7 @@ program MIM
     ! Write a file saying so
     open(unit=99, file='errors.txt', action="write", status="replace", &
         form="formatted")
-    write(99,*) "Can't have both stochastic and sinusoidally varying &
+    write(99, *) "Can't have both stochastic and sinusoidally varying &
         &wind forcings. Choose one."
     close(unit=99)
 
@@ -231,13 +231,13 @@ program MIM
   end if
 
   ! Read in arrays from the input files
-  call read_input_fileU(initUfile,u,0.d0,nx,ny,layers)
-  call read_input_fileV(initVfile,v,0.d0,nx,ny,layers)
-  call read_input_fileH(initHfile,h,hmean,nx,ny,layers)
+  call read_input_fileU(initUfile, u, 0.d0, nx, ny, layers)
+  call read_input_fileV(initVfile, v, 0.d0, nx, ny, layers)
+  call read_input_fileH(initHfile, h, hmean, nx, ny, layers)
 
   if (.not. RedGrav) then
-    call read_input_fileH_2D(depthFile,depth,H0,nx,ny)
-    call read_input_fileH_2D(initEtaFile,eta,0.d0,nx,ny)
+    call read_input_fileH_2D(depthFile, depth, H0, nx, ny)
+    call read_input_fileH_2D(initEtaFile, eta, 0.d0, nx, ny)
     ! Check that depth is negative - it must be less than zero
     if (minval(depth) .lt. 0) then
       print *, "depths must be positive - fix this and try again"
@@ -248,22 +248,22 @@ program MIM
   ! TODO Should probably check that bathymetry file and layer
   ! thicknesses are consistent with each other.
 
-  call read_input_fileU(fUfile,fu,0.d0,nx,ny,1)
-  call read_input_fileV(fVfile,fv,0.d0,nx,ny,1)
+  call read_input_fileU(fUfile, fu, 0.d0, nx, ny, 1)
+  call read_input_fileV(fVfile, fv, 0.d0, nx, ny, 1)
 
-  call read_input_fileU(zonalWindFile,base_wind_x,0.d0,nx,ny,1)
-  call read_input_fileV(meridionalWindFile,base_wind_y,0.d0,nx,ny,1)
+  call read_input_fileU(zonalWindFile, base_wind_x, 0.d0, nx, ny, 1)
+  call read_input_fileV(meridionalWindFile, base_wind_y, 0.d0, nx, ny, 1)
 
-  call read_input_fileH(spongeHTimeScaleFile,spongeHTimeScale, &
-      zeros,nx,ny,layers)
-  call read_input_fileH(spongeHfile,spongeH,hmean,nx,ny,layers)
-  call read_input_fileU(spongeUTimeScaleFile,spongeUTimeScale, &
-      0.d0,nx,ny,layers)
-  call read_input_fileU(spongeUfile,spongeU,0.d0,nx,ny,layers)
-  call read_input_fileV(spongeVTimeScaleFile,spongeVTimeScale, &
-      0.d0,nx,ny,layers)
-  call read_input_fileV(spongeVfile,spongeV,0.d0,nx,ny,layers)
-  call read_input_fileH_2D(wetMaskFile,wetmask,1.d0,nx,ny)
+  call read_input_fileH(spongeHTimeScaleFile, spongeHTimeScale, &
+      zeros, nx, ny, layers)
+  call read_input_fileH(spongeHfile, spongeH, hmean, nx, ny, layers)
+  call read_input_fileU(spongeUTimeScaleFile, spongeUTimeScale, &
+      0.d0, nx, ny, layers)
+  call read_input_fileU(spongeUfile, spongeU, 0.d0, nx, ny, layers)
+  call read_input_fileV(spongeVTimeScaleFile, spongeVTimeScale, &
+      0.d0, nx, ny, layers)
+  call read_input_fileV(spongeVfile, spongeV, 0.d0, nx, ny, layers)
+  call read_input_fileH_2D(wetMaskFile, wetmask, 1.d0, nx, ny)
 
   ! Initialise the average fields
   if (avwrite .ne. 0) then
@@ -276,14 +276,14 @@ program MIM
   end if
 
   ! For now enforce wetmask to have zeros around the edge.
-  wetmask(0,:) = 0d0
-  wetmask(nx+1,:) = 0d0
-  wetmask(:,0) = 0d0
-  wetmask(:,ny+1) = 0d0
+  wetmask(0, :) = 0d0
+  wetmask(nx+1, :) = 0d0
+  wetmask(:, 0) = 0d0
+  wetmask(:, ny+1) = 0d0
   ! TODO, this will change one day when the model can do periodic
   ! boundary conditions.
 
-  call calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
+  call calc_boundary_masks(wetmask, hfacW, hfacE, hfacS, hfacN, nx, ny)
 
   ! Apply the boundary conditions
   ! - Enforce no normal flow boundary condition
@@ -292,10 +292,10 @@ program MIM
   ! - hfacW and hfacS are zero where the transition between
   !   wet and dry cells occurs.
   ! - wetmask is 1 in wet cells, and zero in dry cells.
-  do k = 1,layers
-    ! h(:,:,k) = h(:,:,k)*wetmask(:,:)
-    u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
-    v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
+  do k = 1, layers
+    ! h(:, :, k) = h(:, :, k)*wetmask(:, :)
+    u(:, :, k) = u(:, :, k) * hfacW * wetmask(:, :)
+    v(:, :, k) = v(:, :, k) * hfacS * wetmask(:, :)
   end do
 
   ! If the winds are static, then set wind_ = base_wind_
@@ -316,24 +316,24 @@ program MIM
   if (.not. RedGrav) then
     ! Initialise arrays for pressure solver
     ! a = derivatives of the depth field
-    do j=1,ny
-      do i=1,nx
+    do j=1, ny
+      do i=1, nx
         a(1,i,j)=g_vec(1)*0.5*(depth(i+1,j)+depth(i,j))/dx**2
         a(2,i,j)=g_vec(1)*0.5*(depth(i,j+1)+depth(i,j))/dy**2
         a(3,i,j)=g_vec(1)*0.5*(depth(i,j)+depth(i-1,j))/dx**2
         a(4,i,j)=g_vec(1)*0.5*(depth(i,j)+depth(i,j-1))/dy**2
       end do
     end do
-    do j=1,ny
-      a(1,nx,j)=0.0
-      a(3,1,j)=0.0
+    do j=1, ny
+      a(1, nx, j)=0.0
+      a(3, 1, j)=0.0
     end do
-    do i=1,nx
-      a(2,i,ny)=0.0
-      a(4,i,1)=0.0
+    do i=1, nx
+      a(2, i, ny)=0.0
+      a(4, i, 1)=0.0
     end do
-    do j=1,ny
-      do i=1,nx
+    do j=1, ny
+      do i=1, nx
         a(5,i,j)=-a(1,i,j)-a(2,i,j)-a(3,i,j)-a(4,i,j)
       end do
     end do
@@ -348,8 +348,8 @@ program MIM
     ! Check that the supplied free surface anomaly and layer
     ! thicknesses are consistent
     h_norming = (freesurfFac*eta+depth)/sum(h,3)
-    do k = 1,layers
-      h(:,:,k) = h(:,:,k)*h_norming
+    do k = 1, layers
+      h(:, :, k) = h(:, :, k) * h_norming
     end do
 
     if (maxval(abs(h_norming - 1d0)).gt. 1e-2) then
@@ -370,25 +370,25 @@ program MIM
 
   ! Calculate baroclinic Bernoulli potential
   if (RedGrav) then
-    call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
+    call evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, g_vec)
   else
-    call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
+    call evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
   end if
 
   ! Calculate relative vorticity
-  call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
+  call evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
 
   ! Calculate dhdt, dudt, dvdt at current time step
-  call evaluate_dhdt(dhdtveryold, h,u,v,ah,dx,dy,nx,ny,layers,&
-      spongeHTimeScale,spongeH,wetmask,RedGrav)
+  call evaluate_dhdt(dhdtveryold, h, u, v, ah, dx, dy, nx, ny, layers, &
+      spongeHTimeScale, spongeH, wetmask, RedGrav)
 
-  call evaluate_dudt(dudtveryold, h,u,v,b,zeta,wind_x,fu, au,ar,&
-      slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0,&
-      spongeUTimeScale,spongeU,RedGrav,botDrag)
+  call evaluate_dudt(dudtveryold,  h, u, v, b, zeta, wind_x, fu, au, ar, &
+      slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+      spongeUTimeScale, spongeU, RedGrav, botDrag)
 
-  call evaluate_dvdt(dvdtveryold, h,u,v,b,zeta,wind_y,fv, &
-      au,ar,slip,dx,dy,hfacW,hfacE,nx,ny,layers,rho0, &
-      spongeVTimeScale,spongeV,RedGrav,botDrag)
+  call evaluate_dvdt(dvdtveryold,  h, u, v, b, zeta, wind_y, fv, &
+      au, ar, slip, dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+      spongeVTimeScale, spongeV, RedGrav, botDrag)
 
   ! Calculate the values at half the time interval with Forward Euler
   hhalf = h+0.5d0*dt*dhdtveryold
@@ -397,30 +397,30 @@ program MIM
 
   ! Calculate Bernoulli potential
   if (RedGrav) then
-    call evaluate_b_RedGrav(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec)
+    call evaluate_b_RedGrav(b, hhalf, uhalf, vhalf, nx, ny, layers, g_vec)
   else
-    call evaluate_b_iso(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec,depth)
+    call evaluate_b_iso(b, hhalf, uhalf, vhalf, nx, ny, layers, g_vec, depth)
   end if
 
   ! Calculate relative vorticity
-  call evaluate_zeta(zeta,uhalf,vhalf,nx,ny,layers,dx,dy)
+  call evaluate_zeta(zeta, uhalf, vhalf, nx, ny, layers, dx, dy)
 
-  ! Now calculate d/dt of u,v,h and store as dhdtveryold, dudtveryold
+  ! Now calculate d/dt of u, v, h and store as dhdtveryold, dudtveryold
   ! and dvdtveryold
-  call evaluate_dhdt(dhdtveryold, hhalf,uhalf,vhalf,ah,dx,dy,nx,ny,layers, &
-      spongeHTimeScale,spongeH,wetmask,RedGrav)
+  call evaluate_dhdt(dhdtveryold, hhalf, uhalf, vhalf, ah, dx, dy, nx, ny, layers, &
+      spongeHTimeScale, spongeH, wetmask, RedGrav)
 
-  call evaluate_dudt(dudtveryold, hhalf,uhalf,vhalf,b,zeta, &
-      wind_x,fu, au,ar,slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0, &
-      spongeUTimeScale,spongeU,RedGrav,botDrag)
+  call evaluate_dudt(dudtveryold, hhalf, uhalf, vhalf, b, zeta, &
+      wind_x, fu, au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+      spongeUTimeScale, spongeU, RedGrav, botDrag)
 
-  call evaluate_dvdt(dvdtveryold, hhalf,uhalf,vhalf,b,zeta, &
-      wind_y,fv, au,ar,slip ,dx,dy,hfacW,hfacE,nx,ny,layers,rho0,&
-      spongeVTimeScale,spongeV,RedGrav,botDrag)
+  call evaluate_dvdt(dvdtveryold, hhalf, uhalf, vhalf, b, zeta, &
+      wind_y, fv, au, ar, slip, dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+      spongeVTimeScale, spongeV, RedGrav, botDrag)
   ! These are the values to be stored in the 'veryold' variables ready
   ! to start the proper model run.
 
-  ! Calculate h,u,v with these tendencies
+  ! Calculate h, u, v with these tendencies
   h = h + dt*dhdtveryold
   u = u + dt*dudtveryold
   v = v + dt*dvdtveryold
@@ -432,41 +432,41 @@ program MIM
   ! - hfacW and hfacS are zero where the transition between
   !   wet and dry cells occurs.
   ! - wetmask is 1 in wet cells, and zero in dry cells.
-  do k = 1,layers
-    u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
-    v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
+  do k = 1, layers
+    u(:, :, k) = u(:, :, k) * hfacW * wetmask(:, :)
+    v(:, :, k) = v(:, :, k) * hfacS * wetmask(:, :)
   end do
 
   ! Wrap fields around for periodic simulations
-  call wrap_fields_3D(u,nx,ny,layers)
-  call wrap_fields_3D(v,nx,ny,layers)
-  call wrap_fields_3D(h,nx,ny,layers)
+  call wrap_fields_3D(u, nx, ny, layers)
+  call wrap_fields_3D(v, nx, ny, layers)
+  call wrap_fields_3D(h, nx, ny, layers)
 
   ! -------------------------- negative 1 time step ---------------------------
   ! Code to work out dhdtold, dudtold and dvdtold
 
   ! Calculate Bernoulli potential
   if (RedGrav) then
-    call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
+    call evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, g_vec)
   else
-    call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
+    call evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
   end if
 
   ! Calculate relative vorticity
-  call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
+  call evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
 
   ! Calculate dhdt, dudt, dvdt at current time step
-  call evaluate_dhdt(dhdtold, h,u,v,ah,dx,dy,nx,ny,layers, &
-      spongeHTimeScale,spongeH,wetmask,RedGrav)
+  call evaluate_dhdt(dhdtold, h, u, v, ah, dx, dy, nx, ny, layers, &
+      spongeHTimeScale, spongeH, wetmask, RedGrav)
 
-  call evaluate_dudt(dudtold, h,u,v,b,zeta,wind_x,fu, &
-      au,ar,slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0, &
-      spongeUTimeScale,spongeU,RedGrav,botDrag)
+  call evaluate_dudt(dudtold, h, u, v, b, zeta, wind_x, fu, &
+      au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+      spongeUTimeScale, spongeU, RedGrav, botDrag)
 
   ! If the wind is changed to be meridional this code will need changing
-  call evaluate_dvdt(dvdtold, h,u,v,b,zeta,wind_y,fv, &
-      au,ar,slip, dx,dy,hfacW,hfacE,nx,ny,layers,rho0, &
-      spongeVTimeScale,spongeV,RedGrav,botDrag)
+  call evaluate_dvdt(dvdtold, h, u, v, b, zeta, wind_y, fv, &
+      au, ar, slip, dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+      spongeVTimeScale, spongeV, RedGrav, botDrag)
 
   ! Calculate the values at half the time interval with Forward Euler
   hhalf = h+0.5d0*dt*dhdtold
@@ -475,28 +475,28 @@ program MIM
 
   ! Calculate Bernoulli potential
   if (RedGrav) then
-    call evaluate_b_RedGrav(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec)
+    call evaluate_b_RedGrav(b, hhalf, uhalf, vhalf, nx, ny, layers, g_vec)
   else
-    call evaluate_b_iso(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec,depth)
+    call evaluate_b_iso(b, hhalf, uhalf, vhalf, nx, ny, layers, g_vec, depth)
   end if
 
   ! Calculate relative vorticity
-  call evaluate_zeta(zeta,uhalf,vhalf,nx,ny,layers,dx,dy)
+  call evaluate_zeta(zeta, uhalf, vhalf, nx, ny, layers, dx, dy)
 
-  ! Now calculate d/dt of u,v,h and store as dhdtold, dudtold and dvdtold
-  call evaluate_dhdt(dhdtold, hhalf,uhalf,vhalf,ah,dx,dy,nx,ny,layers, &
-      spongeHTimeScale,spongeH,wetmask,RedGrav)
-  call evaluate_dudt(dudtold, hhalf,uhalf,vhalf,b,zeta,wind_x,&
-      fu, au,ar,slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0,&
-      spongeUTimeScale,spongeU,RedGrav,botDrag)
+  ! Now calculate d/dt of u, v, h and store as dhdtold, dudtold and dvdtold
+  call evaluate_dhdt(dhdtold, hhalf, uhalf, vhalf, ah, dx, dy, nx, ny, layers, &
+      spongeHTimeScale, spongeH, wetmask, RedGrav)
+  call evaluate_dudt(dudtold, hhalf, uhalf, vhalf, b, zeta, wind_x, &
+      fu, au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+      spongeUTimeScale, spongeU, RedGrav, botDrag)
   ! If the wind is changed to be meridional this code will need changing
-  call evaluate_dvdt(dvdtold, hhalf,uhalf,vhalf,b,zeta,wind_y,&
-      fv, au,ar,slip, dx,dy,hfacW,hfacE,nx,ny,layers,rho0,&
-      spongeVTimeScale,spongeV,RedGrav,botDrag)
+  call evaluate_dvdt(dvdtold, hhalf, uhalf, vhalf, b, zeta, wind_y, &
+      fv, au, ar, slip, dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+      spongeVTimeScale, spongeV, RedGrav, botDrag)
   ! These are the values to be stored in the 'old' variables ready to start
   ! the proper model run.
 
-  ! Calculate h,u,v with these tendencies
+  ! Calculate h, u, v with these tendencies
   h = h + dt*dhdtold
   u = u + dt*dudtold
   v = v + dt*dvdtold
@@ -508,15 +508,15 @@ program MIM
   ! - hfacW and hfacS are zero where the transition between
   !   wet and dry cells occurs.
   ! - wetmask is 1 in wet cells, and zero in dry cells.
-  do k = 1,layers
-    u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
-    v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
+  do k = 1, layers
+    u(:, :, k) = u(:, :, k) * hfacW * wetmask(:, :)
+    v(:, :, k) = v(:, :, k) * hfacS * wetmask(:, :)
   end do
 
   ! Wrap fields around for periodic simulations
-  call wrap_fields_3D(u,nx,ny,layers)
-  call wrap_fields_3D(v,nx,ny,layers)
-  call wrap_fields_3D(h,nx,ny,layers)
+  call wrap_fields_3D(u, nx, ny, layers)
+  call wrap_fields_3D(v, nx, ny, layers)
+  call wrap_fields_3D(h, nx, ny, layers)
 
   ! Now the model is ready to start.
   ! - We have h, u, v at the zeroth time step, and the tendencies at
@@ -528,7 +528,7 @@ program MIM
   !!! MAIN LOOP OF THE MODEL STARTS HERE                                    !!!
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  do n=1,nTimeSteps
+  do n=1, nTimeSteps
 
     ! Time varying winds
     if (UseSinusoidWind .eqv. .true.) then
@@ -537,7 +537,7 @@ program MIM
       wind_y = base_wind_y*(wind_alpha +  &
           wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
     else if (UseStochWind .eqv. .true.) then
-      if (mod(n-1,n_stoch_wind).eq.0) then
+      if (mod(n-1, n_stoch_wind).eq.0) then
         ! Gives a pseudorandom number in range 0 <= x < 1
         call random_number(stoch_wind_mag)
         ! Convert to -1 <= x < 1
@@ -551,25 +551,25 @@ program MIM
 
     ! Calculate Bernoulli potential
     if (RedGrav) then
-      call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
+      call evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, g_vec)
     else
-      call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
+      call evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
     end if
 
     ! Calculate relative vorticity
-    call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
+    call evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
 
     ! Calculate dhdt, dudt, dvdt at current time step
-    call evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
-        spongeHTimeScale,spongeH,wetmask,RedGrav)
+    call evaluate_dhdt(dhdt, h, u, v, ah, dx, dy, nx, ny, layers, &
+        spongeHTimeScale, spongeH, wetmask, RedGrav)
 
-    call evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, au,ar,slip,&
-        dx,dy,hfacN,hfacS,nx,ny,layers,rho0,&
-        spongeUTimeScale,spongeU,RedGrav,botDrag)
+    call evaluate_dudt(dudt, h, u, v, b, zeta, wind_x, fu, au, ar, slip, &
+        dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+        spongeUTimeScale, spongeU, RedGrav, botDrag)
 
-    call evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, au,ar,slip, &
-        dx,dy,hfacW,hfacE,nx,ny,layers,rho0,&
-        spongeVTimeScale,spongeV,RedGrav,botDrag)
+    call evaluate_dvdt(dvdt, h, u, v, b, zeta, wind_y, fv, au, ar, slip, &
+        dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+        spongeVTimeScale, spongeV, RedGrav, botDrag)
 
     ! Use dh/dt, du/dt and dv/dt to step h, u and v forward in time with
     ! the Adams-Bashforth third order linear multistep method
@@ -585,50 +585,50 @@ program MIM
     ! - hfacW and hfacS are zero where the transition between
     !   wet and dry cells occurs.
     ! - wetmask is 1 in wet cells, and zero in dry cells.
-    do k = 1,layers
-      unew(:,:,k) = unew(:,:,k)*hfacW*wetmask(:,:)
-      vnew(:,:,k) = vnew(:,:,k)*hfacS*wetmask(:,:)
+    do k = 1, layers
+      unew(:, :, k) = unew(:, :, k) * hfacW * wetmask(:, :)
+      vnew(:, :, k) = vnew(:, :, k) * hfacS * wetmask(:, :)
     end do
 
     ! Do the isopycnal layer physics
     if (.not. RedGrav) then
       ! Calculate the barotropic velocities
-      call calc_baro_u(ub,unew,hnew,eta,freesurfFac,nx,ny,layers)
-      call calc_baro_v(vb,vnew,hnew,eta,freesurfFac,nx,ny,layers)
+      call calc_baro_u(ub, unew, hnew, eta, freesurfFac, nx, ny, layers)
+      call calc_baro_v(vb, vnew, hnew, eta, freesurfFac, nx, ny, layers)
 
       ! Calculate divergence of ub and vb, and solve for the pressure
       ! field that removes it
-      call calc_eta_star(ub,vb,eta,etastar,freesurfFac,nx,ny,dx,dy,dt)
+      call calc_eta_star(ub, vb, eta, etastar, freesurfFac, nx, ny, dx, dy, dt)
       ! print *, maxval(abs(etastar))
 
       ! Prevent barotropic signals from bouncing around outside the
       ! wet region of the model.
       ! etastar = etastar*wetmask
 
-      call SOR_solver(a,etanew,etastar,freesurfFac,nx,ny, &
-          dt,rjac,eps,maxits,n)
+      call SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, &
+          dt, rjac, eps, maxits, n)
       ! print *, maxval(abs(etanew))
 
       etanew = etanew*wetmask
-      call wrap_fields_2D(etanew,nx,ny)
+      call wrap_fields_2D(etanew, nx, ny)
 
       ! Now update the velocities using the barotropic tendency due to
       ! the pressure gradient.
       dudt_bt = 0d0
       dvdt_bt = 0d0
 
-      do i = 1,nx
-        do j = 0,ny
-          do k = 1,layers
+      do i = 1, nx
+        do j = 0, ny
+          do k = 1, layers
             dudt_bt(i,j) = -g_vec(1)*(etanew(i,j) - etanew(i-1,j))/(dx)
             unew(i,j,k) = unew(i,j,k) + dt*dudt_bt(i,j) ! 23d0*dt*dudt_bt(i,j)/12d0
           end do
         end do
       end do
 
-      do i = 0,nx
-        do j = 1,ny
-          do k = 1,layers
+      do i = 0, nx
+        do j = 1, ny
+          do k = 1, layers
             dvdt_bt(i,j) = -g_vec(1)*(etanew(i,j) - etanew(i,j-1))/(dy)
             vnew(i,j,k) = vnew(i,j,k) + dt*dvdt_bt(i,j)! 23d0*dt*dvdt_bt(i,j)/12d0
           end do
@@ -641,9 +641,9 @@ program MIM
       ! between layer thicknesses and ocean depth by scaling
       ! thicknesses to agree with free surface.
 
-      h_norming = (freesurfFac*etanew + depth)/sum(hnew,3)
-      do k = 1,layers
-        hnew(:,:,k) = hnew(:,:,k)*h_norming
+      h_norming = (freesurfFac*etanew + depth) / sum(hnew, 3)
+      do k = 1, layers
+        hnew(:, :, k) = hnew(:, :, k) * h_norming
       end do
 
       if (maxval(abs(h_norming - 1d0)) .gt. 1e-2) then
@@ -658,20 +658,20 @@ program MIM
       ! - hfacW and hfacS are zero where the transition between
       !   wet and dry cells occurs.
       ! - wetmask is 1 in wet cells, and zero in dry cells.
-      do k = 1,layers
-        unew(:,:,k) = unew(:,:,k)*hfacW*wetmask(:,:)
-        vnew(:,:,k) = vnew(:,:,k)*hfacS*wetmask(:,:)
+      do k = 1, layers
+        unew(:, :, k) = unew(:, :, k) * hfacW * wetmask(:, :)
+        vnew(:, :, k) = vnew(:, :, k) * hfacS * wetmask(:, :)
       end do
     end if
 
     ! Code to stop layers from getting too thin
     counter = 0
 
-    do k = 1,layers
-      do j=1,ny
-        do i=1,nx
-          if (hnew(i,j,k) .lt. hmin) then
-            hnew(i,j,k) = hmin
+    do k = 1, layers
+      do j=1, ny
+        do i=1, nx
+          if (hnew(i, j, k) .lt. hmin) then
+            hnew(i, j, k) = hmin
             counter = counter + 1
             if (counter .eq. 1) then
               ! Write a file saying that the layer thickness value
@@ -679,7 +679,7 @@ program MIM
               open(unit=10, file='layer thickness dropped below hmin.txt', &
                   action="write", status="unknown", &
                   form="formatted", position = "append")
-              write(10,1111) n
+              write(10, 1111) n
 1111          format("layer thickness dropped below hmin at time step ", 1i10.10)
               close(unit=10)
             end if
@@ -689,10 +689,10 @@ program MIM
     end do
 
     ! Wrap fields around for periodic simulations
-    call wrap_fields_3D(unew,nx,ny,layers)
-    call wrap_fields_3D(vnew,nx,ny,layers)
-    call wrap_fields_3D(hnew,nx,ny,layers)
-    call wrap_fields_2D(etanew,nx,ny)
+    call wrap_fields_3D(unew, nx, ny, layers)
+    call wrap_fields_3D(vnew, nx, ny, layers)
+    call wrap_fields_3D(hnew, nx, ny, layers)
+    call wrap_fields_2D(etanew, nx, ny)
 
     ! Accumulate average fields
     if (avwrite .ne. 0) then
@@ -727,86 +727,86 @@ program MIM
 
     ! ------------------------ Code for generating output ---------------------
     ! Write data to file?
-    if (mod(n-1,nwrite).eq.0) then
+    if (mod(n-1, nwrite) .eq. 0) then
 
       !
       ! ----------------------- Snapshot Output --------------------
-      write(num,'(i10.10)') n
+      write(num, '(i10.10)') n
 
       ! Output the data to a file
-      open(unit = 10, status='replace',file='output/snap.h.'//num, &
+      open(unit = 10, status='replace', file='output/snap.h.'//num, &
           form='unformatted')
-      write(10) h(1:nx,1:ny,:)
+      write(10) h(1:nx, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace',file='output/snap.u.'//num, &
+      open(unit = 10, status='replace', file='output/snap.u.'//num, &
           form='unformatted')
-      write(10) u(1:nx+1,1:ny,:)
+      write(10) u(1:nx+1, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace',file='output/snap.v.'//num, &
+      open(unit = 10, status='replace', file='output/snap.v.'//num, &
           form='unformatted')
-      write(10) v(1:nx,1:ny+1,:)
+      write(10) v(1:nx, 1:ny+1, :)
       close(10)
       if (.not. RedGrav) then
-        open(unit = 10, status='replace',file='output/snap.eta.'//num, &
+        open(unit = 10, status='replace', file='output/snap.eta.'//num, &
             form='unformatted')
-        write(10) eta(1:nx,1:ny)
+        write(10) eta(1:nx, 1:ny)
         close(10)
       end if
 
       if (DumpWind .eqv. .true.) then
-        open(unit = 10, status='replace',file='output/wind_x.'//num, &
+        open(unit = 10, status='replace', file='output/wind_x.'//num, &
             form='unformatted')
-        write(10) wind_x(1:nx+1,1:ny)
+        write(10) wind_x(1:nx+1, 1:ny)
         close(10)
-        open(unit = 10, status='replace',file='output/wind_y.'//num, &
+        open(unit = 10, status='replace', file='output/wind_y.'//num, &
             form='unformatted')
-        write(10) wind_y(1:nx,1:ny+1)
+        write(10) wind_y(1:nx, 1:ny+1)
         close(10)
       end if
 
       ! Check if there are NaNs in the data
-      call break_if_NaN(h,nx,ny,layers,n)
-      ! call break_if_NaN(u,nx,ny,layers,n)
-      ! call break_if_NaN(v,nx,ny,layers,n)
+      call break_if_NaN(h, nx, ny, layers, n)
+      ! call break_if_NaN(u, nx, ny, layers, n)
+      ! call break_if_NaN(v, nx, ny, layers, n)
 
     end if
 
     ! ----------------------- Average Output -----------------
     if (avwrite .eq. 0) then
       ! OK
-    else if (mod(n-1,avwrite).eq.0) then
+    else if (mod(n-1, avwrite) .eq. 0) then
 
       hav=hav/real(avwrite)
       uav=uav/real(avwrite)
       vav=vav/real(avwrite)
 
-      write(num,'(i10.10)') n
+      write(num, '(i10.10)') n
 
       ! output the data to a file
 
-      open(unit = 10, status='replace',file='output/av.h.'//num, &
+      open(unit = 10, status='replace', file='output/av.h.'//num, &
           form='unformatted')
-      write(10) hav(1:nx,1:ny,:)
+      write(10) hav(1:nx, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace',file='output/av.u.'//num, &
+      open(unit = 10, status='replace', file='output/av.u.'//num, &
           form='unformatted')
-      write(10) uav(1:nx+1,1:ny,:)
+      write(10) uav(1:nx+1, 1:ny, :)
       close(10)
-      open(unit = 10, status='replace',file='output/av.v.'//num, &
+      open(unit = 10, status='replace', file='output/av.v.'//num, &
           form='unformatted')
-      write(10) vav(1:nx,1:ny+1,:)
+      write(10) vav(1:nx, 1:ny+1, :)
       close(10)
       if (.not. RedGrav) then
-        open(unit = 10, status='replace',file='output/av.eta.'//num, &
+        open(unit = 10, status='replace', file='output/av.eta.'//num, &
             form='unformatted')
-        write(10) etaav(1:nx,1:ny)
+        write(10) etaav(1:nx, 1:ny)
         close(10)
       end if
 
       ! Check if there are NaNs in the data
-      call break_if_NaN(h,nx,ny,layers,n)
-      ! call break_if_NaN(u,nx,ny,layers,n)
-      ! call break_if_NaN(v,nx,ny,layers,n)
+      call break_if_NaN(h, nx, ny, layers, n)
+      ! call break_if_NaN(u, nx, ny, layers, n)
+      ! call break_if_NaN(v, nx, ny, layers, n)
 
       ! Reset average quantities
       hav = 0.0
@@ -823,7 +823,7 @@ program MIM
 
   open(unit=10, file='run_finished.txt', action="write", status="unknown", &
       form="formatted", position = "append")
-  write(10,1112) n
+  write(10, 1112) n
 1112 format( "run finished at time step ", 1i10.10)
   close(unit=10)
 
@@ -840,55 +840,55 @@ end program MIM
 
 !> Evaluate the Bornoulli Potential for n-layer physics.
 !! B is evaluated at the tracer point, for each grid box.
-subroutine evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
+subroutine evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
   implicit none
 
   ! Evaluate the baroclinic component of the Bernoulli Potential
   ! (u dot u + Montgomery potential) in the n-layer physics, at centre
   ! of grid box
 
-  double precision, intent(out) :: b(0:nx+1,0:ny+1,layers) !< Bernoulli Potential
+  double precision, intent(out) :: b(0:nx+1, 0:ny+1, layers) !< Bernoulli Potential
   integer, intent(in) :: nx !< number of x grid points
   integer, intent(in) :: ny !< number of y grid points
   integer, intent(in) :: layers !< number of layers
-  integer i,j,k
-  double precision, intent(in) :: depth(0:nx+1,0:ny+1) !< total depth of fluid
-  double precision z(0:nx,0:ny,layers)
-  double precision, intent(in) :: h(0:nx+1,0:ny+1,layers) !< layer thicknesses
-  double precision, intent(in) :: u(0:nx+1,0:ny+1,layers) !< zonal velocities
-  double precision, intent(in) :: v(0:nx+1,0:ny+1,layers) !< meridional velocities
+  integer i, j, k
+  double precision, intent(in) :: depth(0:nx+1, 0:ny+1) !< total depth of fluid
+  double precision z(0:nx, 0:ny, layers)
+  double precision, intent(in) :: h(0:nx+1, 0:ny+1, layers) !< layer thicknesses
+  double precision, intent(in) :: u(0:nx+1, 0:ny+1, layers) !< zonal velocities
+  double precision, intent(in) :: v(0:nx+1, 0:ny+1, layers) !< meridional velocities
   double precision, intent(in) :: g_vec(layers) !< reduced gravity at each interface
-  double precision M(0:nx+1,0:ny+1,layers)
+  double precision M(0:nx+1, 0:ny+1, layers)
 
   ! Calculate layer interface locations
   z = 0d0
-  z(:,:,layers) = -depth
+  z(:, :, layers) = -depth
 
-  do k = 1,layers-1
-    z(:,:,layers - k) = z(:,:,layers-k+1) + h(:,:,layers-k+1)
+  do k = 1, layers-1
+    z(:, :, layers - k) = z(:, :, layers-k+1) + h(:, :, layers-k+1)
   end do
 
   ! Calculate Montogmery potential
   ! The following loop is to get the baroclinic Montgomery potential
   ! in each layer
   M = 0d0
-  do k = 2,layers
-    M(:,:,k) = M(:,:,k-1) + g_vec(k)*z(:,:,k-1)
+  do k = 2, layers
+    M(:, :, k) = M(:, :, k-1) + g_vec(k) * z(:, :, k-1)
   end do
 
   b = 0d0
   ! No baroclinic pressure contribution to the first layer Bernoulli potential
   ! (the barotropic pressure contributes, but that's not done here).
-  ! do j = 1,ny-1
-  !     do i = 1,nx-1
+  ! do j = 1, ny-1
+  !     do i = 1, nx-1
   !         b(i,j,1) = (u(i,j,1)**2+u(i+1,j,1)**2+v(i,j,1)**2+v(i,j+1,1)**2)/4.0d0
   !     end do
   ! end do
 
   ! For the rest of the layers we get a baroclinic pressure contribution
-  do k = 1,layers ! move through the different layers of the model
-    do j=1,ny ! move through longitude
-      do i=1,nx ! move through latitude
+  do k = 1, layers ! move through the different layers of the model
+    do j=1, ny ! move through longitude
+      do i=1, nx ! move through latitude
         b(i,j,k)= M(i,j,k) + (u(i,j,k)**2+u(i+1,j,k)**2+v(i,j,k)**2+v(i,j+1,k)**2)/4.0d0
         ! Add the (u^2 + v^2)/2 term to the Montgomery Potential
       end do
@@ -900,31 +900,31 @@ end subroutine evaluate_b_iso
 
 ! -----------------------------------------------------------------------------
 
-subroutine evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,gr)
+subroutine evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, gr)
   implicit none
 
   ! Evaluate Bernoulli Potential at centre of grid box
-  integer nx,ny,layers
-  integer i,j,k,l,m
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision v(0:nx+1,0:ny+1,layers)
-  double precision b(0:nx+1,0:ny+1,layers)
+  integer nx, ny, layers
+  integer i, j, k, l, m
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision v(0:nx+1, 0:ny+1, layers)
+  double precision b(0:nx+1, 0:ny+1, layers)
   double precision gr(layers)
   double precision h_temp, b_proto
 
   b = 0d0
 
-  do k = 1,layers ! move through the different layers of the model
-    do j=1,ny ! move through longitude
-      do i=1,nx ! move through latitude
+  do k = 1, layers ! move through the different layers of the model
+    do j=1, ny ! move through longitude
+      do i=1, nx ! move through latitude
         ! The following loops are to get the pressure term in the
         ! Bernoulli Potential
         b_proto = 0d0
-        do l = k,layers
+        do l = k, layers
           h_temp = 0d0
-          do m = 1,l
-            h_temp = h_temp + h(i,j,m) ! sum up the layer thicknesses
+          do m = 1, l
+            h_temp = h_temp + h(i, j, m) ! sum up the layer thicknesses
           end do
           ! Sum up the product of reduced gravity and summed layer
           ! thicknesses to form the pressure componenet of the
@@ -944,22 +944,22 @@ end subroutine evaluate_b_RedGrav
 ! -----------------------------------------------------------------------------
 !> Evaluate relative vorticity at lower left grid boundary (du/dy
 !! and dv/dx are at lower left corner as well)
-subroutine evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
+subroutine evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
   implicit none
 
-  integer nx,ny,layers
-  integer i,j,k
-  double precision h(0:nx,0:ny,layers)
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision v(0:nx+1,0:ny+1,layers)
-  double precision zeta(0:nx+1,0:ny+1,layers)
+  integer nx, ny, layers
+  integer i, j, k
+  double precision h(0:nx, 0:ny, layers)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision v(0:nx+1, 0:ny+1, layers)
+  double precision zeta(0:nx+1, 0:ny+1, layers)
   double precision dx, dy
 
   zeta = 0d0
 
-  do k = 1,layers
-    do j=1,ny+1
-      do i=1,nx+1
+  do k = 1, layers
+    do j=1, ny+1
+      do i=1, nx+1
         zeta(i,j,k)=(v(i,j,k)-v(i-1,j,k))/dx-(u(i,j,k)-u(i,j-1,k))/dy
       end do
     end do
@@ -971,23 +971,23 @@ end subroutine evaluate_zeta
 ! -----------------------------------------------------------------------------
 !> Calculate the tendency of layer thickness for each of the active layers
 !! dh/dt is in the centre of each grid point.
-subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
-    spongeTimeScale,spongeH,wetmask,RedGrav)
+subroutine evaluate_dhdt(dhdt, h, u, v, ah, dx, dy, nx, ny, layers, &
+    spongeTimeScale, spongeH, wetmask, RedGrav)
   implicit none
 
   ! dhdt is evaluated at the centre of the grid box
-  integer nx,ny,layers
-  integer i,j,k
-  double precision dhdt(0:nx+1,0:ny+1,layers)
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision v(0:nx+1,0:ny+1,layers)
+  integer nx, ny, layers
+  integer i, j, k
+  double precision dhdt(0:nx+1, 0:ny+1, layers)
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision v(0:nx+1, 0:ny+1, layers)
   ! Thickness tendency due to thickness diffusion (equivalent to Gent
   ! McWilliams in a z coordinate model)
-  double precision dhdt_GM(0:nx+1,0:ny+1,layers)
-  double precision spongeTimeScale(0:nx+1,0:ny+1,layers)
-  double precision spongeH(0:nx+1,0:ny+1,layers)
-  double precision wetmask(0:nx+1,0:ny+1)
+  double precision dhdt_GM(0:nx+1, 0:ny+1, layers)
+  double precision spongeTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision spongeH(0:nx+1, 0:ny+1, layers)
+  double precision wetmask(0:nx+1, 0:ny+1)
   double precision dx, dy
   double precision ah(layers)
   logical :: RedGrav
@@ -998,9 +998,9 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
 
   ! Loop through all layers except lowest and calculate
   ! thickness tendency due to diffusive mass fluxes
-  do k = 1,layers-1
-    do j=1,ny
-      do i=1,nx
+  do k = 1, layers-1
+    do j=1, ny
+      do i=1, nx
         dhdt_GM(i,j,k) = &
             ah(k)*(h(i+1,j,k)*wetmask(i+1,j)    &
               + (1d0 - wetmask(i+1,j))*h(i,j,k) & ! reflect around boundary
@@ -1022,8 +1022,8 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
   ! using n-layer physics it is constrained to balance the layers
   ! above it.
   if (RedGrav) then
-    do j=1,ny
-      do i=1,nx
+    do j=1, ny
+      do i=1, nx
         dhdt_GM(i,j,layers) = &
             ah(layers)*(h(i+1,j,layers)*wetmask(i+1,j)   &
               + (1d0 - wetmask(i+1,j))*h(i,j,layers)     & ! boundary
@@ -1041,16 +1041,16 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
   else if (.not. RedGrav) then ! using n-layer physics
     ! Calculate bottom layer thickness tendency to balance layers above.
     ! In the flat-bottomed case this will give the same answer.
-    dhdt_GM(:,:,layers) = -sum(dhdt_GM(:,:,:layers-1),3)
+    dhdt_GM(:,:,layers) = -sum(dhdt_GM(:,:,:layers-1), 3)
   end if
 
   ! Now add this to the thickness tendency due to the flow field and
   ! sponge regions
   dhdt = 0d0
 
-  do k = 1,layers
-    do j=1,ny
-      do i=1,nx
+  do k = 1, layers
+    do j=1, ny
+      do i=1, nx
         dhdt(i,j,k) = &
             dhdt_GM(i,j,k) & ! horizontal thickness diffusion
             - ((h(i,j,k)+h(i+1,j,k))*u(i+1,j,k) &
@@ -1063,11 +1063,11 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
   end do
 
   ! Make sure the dynamics are only happening in the wet grid points.
-  do k = 1,layers
-    dhdt(:,:,k) = dhdt(:,:,k)*wetmask
+  do k = 1, layers
+    dhdt(:, :, k) = dhdt(:, :, k) * wetmask
   end do
 
-  call wrap_fields_3D(dhdt,nx,ny,layers)
+  call wrap_fields_3D(dhdt, nx, ny, layers)
 
   return
 end subroutine evaluate_dhdt
@@ -1075,36 +1075,36 @@ end subroutine evaluate_dhdt
 ! -----------------------------------------------------------------------------
 !> Calculate the tendency of zonal velocity for each of the active layers
 
-subroutine evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, &
-    au,ar,slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0, &
-    spongeTimeScale,spongeU,RedGrav,botDrag)
+subroutine evaluate_dudt(dudt, h, u, v, b, zeta, wind_x, fu, &
+    au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
+    spongeTimeScale, spongeU, RedGrav, botDrag)
   implicit none
 
-  ! dudt(i,j) is evaluated at the centre of the left edge of the grid
-  ! box, the same place as u(i,j).
-  integer nx,ny,layers
-  integer i,j,k
-  double precision dudt(0:nx+1,0:ny+1,layers)
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision v(0:nx+1,0:ny+1,layers)
-  double precision fu(0:nx+1,0:ny+1)
-  double precision zeta(0:nx+1,0:ny+1,layers)
-  double precision b(0:nx+1,0:ny+1,layers)
-  double precision spongeTimeScale(0:nx+1,0:ny+1,layers)
-  double precision spongeU(0:nx+1,0:ny+1,layers)
-  double precision wind_x(0:nx+1,0:ny+1)
+  ! dudt(i, j) is evaluated at the centre of the left edge of the grid
+  ! box, the same place as u(i, j).
+  integer nx, ny, layers
+  integer i, j, k
+  double precision dudt(0:nx+1, 0:ny+1, layers)
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision v(0:nx+1, 0:ny+1, layers)
+  double precision fu(0:nx+1, 0:ny+1)
+  double precision zeta(0:nx+1, 0:ny+1, layers)
+  double precision b(0:nx+1, 0:ny+1, layers)
+  double precision spongeTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision spongeU(0:nx+1, 0:ny+1, layers)
+  double precision wind_x(0:nx+1, 0:ny+1)
   double precision dx, dy
   double precision au, ar, rho0, slip, botDrag
-  double precision hfacN(0:nx+1,0:ny+1)
-  double precision hfacS(0:nx+1,0:ny+1)
+  double precision hfacN(0:nx+1, 0:ny+1)
+  double precision hfacS(0:nx+1, 0:ny+1)
   logical :: RedGrav
 
   dudt = 0d0
 
-  do k = 1,layers
-    do i=1,nx
-      do j=1,ny
+  do k = 1, layers
+    do i=1, nx
+      do j=1, ny
         dudt(i,j,k) = au*(u(i+1,j,k)+u(i-1,j,k)-2.0d0*u(i,j,k))/(dx*dx) & ! x-component
             + au*(u(i,j+1,k)+u(i,j-1,k)-2.0d0*u(i,j,k) &
               ! boundary conditions
@@ -1137,7 +1137,7 @@ subroutine evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, &
     end do
   end do
 
-  call wrap_fields_3D(dudt,nx,ny,layers)
+  call wrap_fields_3D(dudt, nx, ny, layers)
 
   return
 end subroutine evaluate_dudt
@@ -1145,37 +1145,37 @@ end subroutine evaluate_dudt
 ! -----------------------------------------------------------------------------
 !> Calculate the tendency of meridional velocity for each of the active layers
 
-subroutine evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, &
-    au,ar,slip,dx,dy,hfacW,hfacE,nx,ny,layers,rho0, &
-    spongeTimeScale,spongeV,RedGrav,botDrag)
+subroutine evaluate_dvdt(dvdt, h, u, v, b, zeta, wind_y, fv, &
+    au, ar, slip, dx, dy, hfacW, hfacE, nx, ny, layers, rho0, &
+    spongeTimeScale, spongeV, RedGrav, botDrag)
   implicit none
 
-  ! dvdt(i,j) is evaluated at the centre of the bottom edge of the
-  ! grid box, the same place as v(i,j)
-  integer nx,ny,layers
-  integer i,j,k
-  double precision dvdt(0:nx+1,0:ny+1,layers)
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision v(0:nx+1,0:ny+1,layers)
-  double precision fv(0:nx+1,0:ny+1)
-  double precision zeta(0:nx+1,0:ny+1,layers)
-  double precision b(0:nx+1,0:ny+1,layers)
-  double precision spongeTimeScale(0:nx+1,0:ny+1,layers)
-  double precision spongeV(0:nx+1,0:ny+1,layers)
-  double precision wind_y(0:nx+1,0:ny+1)
+  ! dvdt(i, j) is evaluated at the centre of the bottom edge of the
+  ! grid box, the same place as v(i, j)
+  integer nx, ny, layers
+  integer i, j, k
+  double precision dvdt(0:nx+1, 0:ny+1, layers)
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision v(0:nx+1, 0:ny+1, layers)
+  double precision fv(0:nx+1, 0:ny+1)
+  double precision zeta(0:nx+1, 0:ny+1, layers)
+  double precision b(0:nx+1, 0:ny+1, layers)
+  double precision spongeTimeScale(0:nx+1, 0:ny+1, layers)
+  double precision spongeV(0:nx+1, 0:ny+1, layers)
+  double precision wind_y(0:nx+1, 0:ny+1)
   double precision dx, dy
   double precision au, ar, slip, botDrag
   double precision rho0
-  double precision hfacW(0:nx+1,0:ny+1)
-  double precision hfacE(0:nx+1,0:ny+1)
+  double precision hfacW(0:nx+1, 0:ny+1)
+  double precision hfacE(0:nx+1, 0:ny+1)
   logical :: RedGrav
 
   dvdt = 0d0
 
-  do k = 1,layers
-    do j=1,ny
-      do i=1,nx
+  do k = 1, layers
+    do j=1, ny
+      do i=1, nx
         dvdt(i,j,k) = &
             au*(v(i+1,j,k)+v(i-1,j,k)-2.0d0*v(i,j,k) &
               ! boundary conditions
@@ -1208,40 +1208,40 @@ subroutine evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, &
     end do
   end do
 
-  call wrap_fields_3D(dvdt,nx,ny,layers)
+  call wrap_fields_3D(dvdt, nx, ny, layers)
 
   return
 end subroutine evaluate_dvdt
 
 ! -----------------------------------------------------------------------------
 !> Calculate the barotropic u velocity
-subroutine calc_baro_u(ub,u,h,eta,freesurfFac,nx,ny,layers)
+subroutine calc_baro_u(ub, u, h, eta, freesurfFac, nx, ny, layers)
   implicit none
 
-  integer nx,ny,layers
-  integer i,j,k
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision h_temp(0:nx+1,0:ny+1,layers)
-  double precision eta(0:nx+1,0:ny+1)
+  integer nx, ny, layers
+  integer i, j, k
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision h_temp(0:nx+1, 0:ny+1, layers)
+  double precision eta(0:nx+1, 0:ny+1)
   double precision freesurfFac
-  double precision u(0:nx+1,0:ny+1,layers)
-  double precision ub(0:nx+1,0:ny+1)
+  double precision u(0:nx+1, 0:ny+1, layers)
+  double precision ub(0:nx+1, 0:ny+1)
 
   ub = 0d0
 
   h_temp = h
   ! add free surface elevation to the upper layer
-  h_temp(:,:,1) = h(:,:,1) + eta*freesurfFac
+  h_temp(:, :, 1) = h(:, :, 1) + eta*freesurfFac
 
-  do i = 1,nx
-    do j = 1,ny
-      do k = 1,layers
+  do i = 1, nx
+    do j = 1, ny
+      do k = 1, layers
         ub(i,j) = ub(i,j) + u(i,j,k)*(h_temp(i,j,k)+h_temp(i-1,j,k))/2d0
       end do
     end do
   end do
 
-  call wrap_fields_2D(ub,nx,ny)
+  call wrap_fields_2D(ub, nx, ny)
 
   return
 end subroutine calc_baro_u
@@ -1249,33 +1249,33 @@ end subroutine calc_baro_u
 ! -----------------------------------------------------------------------------
 
 !> Calculate the barotropic v velocity
-subroutine calc_baro_v(vb,v,h,eta,freesurfFac,nx,ny,layers)
+subroutine calc_baro_v(vb, v, h, eta, freesurfFac, nx, ny, layers)
   implicit none
 
-  integer nx,ny,layers
-  integer i,j,k
-  double precision h(0:nx+1,0:ny+1,layers)
-  double precision h_temp(0:nx+1,0:ny+1,layers)
-  double precision eta(0:nx+1,0:ny+1)
+  integer nx, ny, layers
+  integer i, j, k
+  double precision h(0:nx+1, 0:ny+1, layers)
+  double precision h_temp(0:nx+1, 0:ny+1, layers)
+  double precision eta(0:nx+1, 0:ny+1)
   double precision freesurfFac
-  double precision v(0:nx+1,0:ny+1,layers)
-  double precision vb(0:nx+1,0:ny+1)
+  double precision v(0:nx+1, 0:ny+1, layers)
+  double precision vb(0:nx+1, 0:ny+1)
 
   vb = 0d0
 
   h_temp = h
   ! add free surface elevation to the upper layer
-  h_temp(:,:,1) = h(:,:,1) + eta*freesurfFac
+  h_temp(:, :, 1) = h(:, :, 1) + eta*freesurfFac
 
-  do i = 1,nx
-    do j = 1,ny
-      do k = 1,layers
+  do i = 1, nx
+    do j = 1, ny
+      do k = 1, layers
         vb(i,j) = vb(i,j) + v(i,j,k)*(h_temp(i,j,k)+h_temp(i,j-1,k))/2d0
       end do
     end do
   end do
 
-  call wrap_fields_2D(vb,nx,ny)
+  call wrap_fields_2D(vb, nx, ny)
 
   return
 end subroutine calc_baro_v
@@ -1285,27 +1285,27 @@ end subroutine calc_baro_v
 !> Calculate the free surface anomaly using the velocities
 !! timestepped with the tendencies excluding the free surface
 !! pressure gradient.
-subroutine calc_eta_star(ub,vb,eta,etastar,freesurfFac,nx,ny,dx,dy,dt)
+subroutine calc_eta_star(ub, vb, eta, etastar, freesurfFac, nx, ny, dx, dy, dt)
   implicit none
 
-  integer nx,ny,layers
-  integer i,j,k
-  double precision eta(0:nx+1,0:ny+1)
-  double precision etastar(0:nx+1,0:ny+1)
-  double precision ub(0:nx+1,0:ny+1)
-  double precision vb(0:nx+1,0:ny+1)
-  double precision freesurfFac, dx,dy,dt
+  integer nx, ny, layers
+  integer i, j, k
+  double precision eta(0:nx+1, 0:ny+1)
+  double precision etastar(0:nx+1, 0:ny+1)
+  double precision ub(0:nx+1, 0:ny+1)
+  double precision vb(0:nx+1, 0:ny+1)
+  double precision freesurfFac, dx, dy, dt
 
   etastar = 0d0
 
-  do i = 1,nx
-    do j = 1,ny
+  do i = 1, nx
+    do j = 1, ny
       etastar(i,j) = freesurfFac*eta(i,j) - &
           dt*((ub(i+1,j) - ub(i,j))/dx + (vb(i,j+1) - vb(i,j))/dy)
     end do
   end do
 
-  call wrap_fields_2D(etastar,nx,ny)
+  call wrap_fields_2D(etastar, nx, ny)
 
   return
 end subroutine calc_eta_star
@@ -1315,18 +1315,18 @@ end subroutine calc_eta_star
 !! Euler timestepping for the free surface anomaly, or for the surface
 !! pressure required to keep the barotropic flow nondivergent.
 
-subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
+subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, rjac, eps, maxits, n)
   implicit none
 
-  double precision a(5,nx,ny)
-  double precision etanew(0:nx+1,0:ny+1)
-  double precision etastar(0:nx+1,0:ny+1)
+  double precision a(5, nx, ny)
+  double precision etanew(0:nx+1, 0:ny+1)
+  double precision etastar(0:nx+1, 0:ny+1)
   double precision freesurfFac
-  integer nx,ny,i,j,maxits,n,nit
+  integer nx, ny, i, j, maxits, n, nit
   double precision dt
   double precision rjac, eps
-  double precision rhs(nx,ny)
-  double precision res(nx,ny)
+  double precision rhs(nx, ny)
+  double precision res(nx, ny)
   double precision norm, norm0, norm_old
   double precision relax_param
   character(30) Format
@@ -1340,8 +1340,8 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
   ! Calculate initial residual, so that we can stop the loop when the
   ! current residual = norm0*eps
   norm0 = 0.d0
-  do i = 1,nx
-    do j = 1,ny
+  do i = 1, nx
+    do j = 1, ny
       res(i,j) = &
           a(1,i,j)*etanew(i+1,j) &
           + a(2,i,j)*etanew(i,j+1) &
@@ -1357,11 +1357,11 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
 
   ! norm_old = norm0
 
-  do nit = 1,maxits
+  do nit = 1, maxits
     ! norm_old = norm
     norm=0.d0
-    do i=1,nx
-      do j=1,ny
+    do i=1, nx
+      do j=1, ny
         res(i,j) = &
             a(1,i,j)*etanew(i+1,j) &
             + a(2,i,j)*etanew(i,j+1) &
@@ -1380,7 +1380,7 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
       relax_param=1.d0/(1.d0-0.25d0*rjac**2*relax_param)
     end if
 
-    call wrap_fields_2D(etanew,nx,ny)
+    call wrap_fields_2D(etanew, nx, ny)
 
     if (nit.gt.1.and.norm.lt.eps*norm0) then
       ! print 10014,  eps,  nit
@@ -1393,7 +1393,7 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
     end if
   end do
 
-  print *,'warning: maximum iterations exceeded at time step ', n
+  print *, 'warning: maximum iterations exceeded at time step ', n
 
   return
 end subroutine SOR_solver
@@ -1401,22 +1401,22 @@ end subroutine SOR_solver
 ! -----------------------------------------------------------------------------
 !> Check to see if there are any NaNs in the data field and stop the
 !! calculation if any are found.
-subroutine break_if_NaN(data,nx,ny,layers,n)
+subroutine break_if_NaN(data, nx, ny, layers, n)
   implicit none
 
   ! To stop the program if it detects at NaN in the variable being checked
 
-  integer nx,ny,layers,n,i,j,k
-  double precision data(0:nx+1, 0:ny+1,layers)
+  integer nx, ny, layers, n, i, j, k
+  double precision data(0:nx+1, 0:ny+1, layers)
 
-  do k=1,layers
-    do j=1,ny
-      do i=1,nx
-        if (data(i,j,k).ne.data(i,j,k))  then
+  do k=1, layers
+    do j=1, ny
+      do i=1, nx
+        if (data(i,j,k) .ne. data(i,j,k)) then
           ! write a file saying so
           open(unit=10, file='NaN detected.txt', action="write", &
               status="replace", form="formatted")
-          write(10,1000) n
+          write(10, 1000) n
 1000      format( "NaN detected at time step ", 1i10.10)
           close(unit=10)
           ! print it on the screen
@@ -1439,124 +1439,124 @@ end subroutine break_if_NaN
 !! 0 means barrier
 !! 1 mean open
 
-subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
+subroutine calc_boundary_masks(wetmask, hfacW, hfacE, hfacS, hfacN, nx, ny)
   implicit none
 
   integer nx !< number of grid points in x direction
   integer ny !< number of grid points in y direction
-  double precision wetmask(0:nx+1,0:ny+1)
-  double precision temp(0:nx+1,0:ny+1)
-  double precision hfacW(0:nx+1,0:ny+1)
-  double precision hfacE(0:nx+1,0:ny+1)
-  double precision hfacN(0:nx+1,0:ny+1)
-  double precision hfacS(0:nx+1,0:ny+1)
-  integer i,j
+  double precision wetmask(0:nx+1, 0:ny+1)
+  double precision temp(0:nx+1, 0:ny+1)
+  double precision hfacW(0:nx+1, 0:ny+1)
+  double precision hfacE(0:nx+1, 0:ny+1)
+  double precision hfacN(0:nx+1, 0:ny+1)
+  double precision hfacS(0:nx+1, 0:ny+1)
+  integer i, j
 
   hfacW = 1d0
 
   temp = 0.0
-  do j = 0,ny+1
-    do i = 1,nx+1
-      temp(i,j) = wetmask(i-1,j)- wetmask(i,j)
+  do j = 0, ny+1
+    do i = 1, nx+1
+      temp(i, j) = wetmask(i-1, j) - wetmask(i, j)
     end do
   end do
 
-  do j = 0,ny+1
-    do i = 1,nx+1
-      if (temp(i,j) .ne. 0.0) then
-        hfacW(i,j) = 0d0
+  do j = 0, ny+1
+    do i = 1, nx+1
+      if (temp(i, j) .ne. 0.0) then
+        hfacW(i, j) = 0d0
       end if
     end do
   end do
 
   ! and now for all  western cells
-  hfacW(0,:) = hfacW(nx,:)
+  hfacW(0, :) = hfacW(nx, :)
 
   hfacE = 1d0
 
   temp = 0.0
-  do j = 0,ny+1
-    do i = 0,nx
-      temp(i,j) = wetmask(i,j)- wetmask(i+1,j)
+  do j = 0, ny+1
+    do i = 0, nx
+      temp(i, j) = wetmask(i, j) - wetmask(i+1, j)
     end do
   end do
 
-  do j = 0,ny+1
-    do i = 0,nx
-      if (temp(i,j) .ne. 0.0) then
-        hfacE(i,j) = 0d0
+  do j = 0, ny+1
+    do i = 0, nx
+      if (temp(i, j) .ne. 0.0) then
+        hfacE(i, j) = 0d0
       end if
     end do
   end do
 
   ! and now for all  eastern cells
-  hfacE(nx+1,:) = hfacE(1,:)
+  hfacE(nx+1, :) = hfacE(1, :)
 
   hfacS = 1
 
   temp = 0.0
-  do j = 1,ny+1
-    do i = 0,nx+1
-      temp(i,j) = wetmask(i,j-1)- wetmask(i,j)
+  do j = 1, ny+1
+    do i = 0, nx+1
+      temp(i, j) = wetmask(i, j-1) - wetmask(i, j)
     end do
   end do
 
-  do j = 1,ny+1
-    do i = 0,nx+1
-      if (temp(i,j) .ne. 0.0) then
-        hfacS(i,j) = 0d0
+  do j = 1, ny+1
+    do i = 0, nx+1
+      if (temp(i, j) .ne. 0.0) then
+        hfacS(i, j) = 0d0
       end if
     end do
   end do
 
   ! all southern cells
-  hfacS(:,0) = hfacS(:,ny)
+  hfacS(:, 0) = hfacS(:, ny)
 
   hfacN = 1
   temp = 0.0
-  do j = 0,ny
-    do i = 0,nx+1
-      temp(i,j) = wetmask(i,j)- wetmask(i,j+1)
+  do j = 0, ny
+    do i = 0, nx+1
+      temp(i, j) = wetmask(i, j) - wetmask(i, j+1)
     end do
   end do
 
-  do j = 0,ny
-    do i = 0,nx+1
-      if (temp(i,j) .ne. 0.0) then
-        hfacN(i,j) = 0d0
+  do j = 0, ny
+    do i = 0, nx+1
+      if (temp(i, j) .ne. 0.0) then
+        hfacN(i, j) = 0d0
       end if
     end do
   end do
   ! all northern cells
-  hfacN(:,ny+1) = hfacN(:,1)
+  hfacN(:, ny+1) = hfacN(:, 1)
 
   return
 end subroutine calc_boundary_masks
 
 ! -----------------------------------------------------------------------------
 
-subroutine read_input_fileH(name,array,default,nx,ny,layers)
+subroutine read_input_fileH(name, array, default, nx, ny, layers)
   implicit none
 
   character(30) name
   integer nx, ny, layers, k
-  double precision array(0:nx+1,0:ny+1,layers), default(layers)
-  double precision array_small(nx,ny,layers)
+  double precision array(0:nx+1, 0:ny+1, layers), default(layers)
+  double precision array_small(nx, ny, layers)
 
   if (name.ne.'') then
     open(unit = 10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
-    array(1:nx,1:ny,:) = array_small
+    array(1:nx, 1:ny, :) = array_small
     ! wrap array around for periodicity
-    array(0,:,:) = array(nx,:,:)
-    array(nx+1,:,:) = array(1,:,:)
-    array(:,0,:) = array(:,ny,:)
-    array(:,ny+1,:) = array(:,1,:)
+    array(0, :, :) = array(nx, :, :)
+    array(nx+1, :, :) = array(1, :, :)
+    array(:, 0, :) = array(:, ny, :)
+    array(:, ny+1, :) = array(:, 1, :)
   else
-    do k = 1,layers
-      array(:,:,k) = default(k)
+    do k = 1, layers
+      array(:, :, k) = default(k)
     end do
   end if
 
@@ -1565,25 +1565,25 @@ end subroutine read_input_fileH
 
 ! -----------------------------------------------------------------------------
 
-subroutine read_input_fileH_2D(name,array,default,nx,ny)
+subroutine read_input_fileH_2D(name, array, default, nx, ny)
   implicit none
 
   character(30) name
   integer nx, ny
-  double precision array(0:nx+1,0:ny+1), default
-  double precision array_small(nx,ny)
+  double precision array(0:nx+1, 0:ny+1), default
+  double precision array_small(nx, ny)
 
   if (name.ne.'') then
     open(unit = 10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
-    array(1:nx,1:ny) = array_small
+    array(1:nx, 1:ny) = array_small
     ! wrap array around for periodicity
-    array(0,:) = array(nx,:)
-    array(nx+1,:) = array(1,:)
-    array(:,0) = array(:,ny)
-    array(:,ny+1) = array(:,1)
+    array(0, :) = array(nx, :)
+    array(nx+1, :) = array(1, :)
+    array(:, 0) = array(:, ny)
+    array(:, ny+1) = array(:, 1)
   else
     array = default
   end if
@@ -1593,25 +1593,25 @@ end subroutine read_input_fileH_2D
 
 ! -----------------------------------------------------------------------------
 
-subroutine read_input_fileU(name,array,default,nx,ny,layers)
+subroutine read_input_fileU(name, array, default, nx, ny, layers)
   implicit none
 
   character(30) name
-  integer nx, ny,layers
-  double precision array(0:nx+1,0:ny+1,layers), default
-  double precision array_small(nx+1,ny,layers)
+  integer nx, ny, layers
+  double precision array(0:nx+1, 0:ny+1, layers), default
+  double precision array_small(nx+1, ny, layers)
 
   if (name.ne.'') then
     open(unit = 10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
-    array(1:nx+1,1:ny,:) = array_small
+    array(1:nx+1, 1:ny, :) = array_small
     ! wrap array around for periodicity
-    array(0,:,:) = array(nx,:,:)
-    array(nx+1,:,:) = array(1,:,:)
-    array(:,0,:) = array(:,ny,:)
-    array(:,ny+1,:) = array(:,1,:)
+    array(0, :, :) = array(nx, :, :)
+    array(nx+1, :, :) = array(1, :, :)
+    array(:, 0, :) = array(:, ny, :)
+    array(:, ny+1, :) = array(:, 1, :)
   else
     array = default
   end if
@@ -1621,25 +1621,25 @@ end subroutine read_input_fileU
 
 ! -----------------------------------------------------------------------------
 
-subroutine read_input_fileV(name,array,default,nx,ny,layers)
+subroutine read_input_fileV(name, array, default, nx, ny, layers)
   implicit none
 
   character(30) name
   integer nx, ny, layers
-  double precision array(0:nx+1,0:ny+1,layers), default
-  double precision array_small(nx,ny+1,layers)
+  double precision array(0:nx+1, 0:ny+1, layers), default
+  double precision array_small(nx, ny+1, layers)
 
   if (name.ne.'') then
     open(unit = 10, form='unformatted', file=name)
     read(10) array_small
     close(10)
 
-    array(1:nx,1:ny+1,:) = array_small
+    array(1:nx, 1:ny+1, :) = array_small
     ! wrap array around for periodicity
-    array(0,:,:) = array(nx,:,:)
-    array(nx+1,:,:) = array(1,:,:)
-    array(:,0,:) = array(:,ny,:)
-    array(:,ny+1,:) = array(:,1,:)
+    array(0, :, :) = array(nx, :, :)
+    array(nx+1, :, :) = array(1, :, :)
+    array(:, 0, :) = array(:, ny, :)
+    array(:, ny+1, :) = array(:, 1, :)
   else
     array = default
   end if
@@ -1650,17 +1650,17 @@ end subroutine read_input_fileV
 !-----------------------------------------------------------------
 !> Wrap 3D fields around for periodic boundary conditions
 
-subroutine wrap_fields_3D(array,nx,ny,layers)
+subroutine wrap_fields_3D(array, nx, ny, layers)
   implicit none
 
-  double precision array(0:nx+1,0:ny+1,layers)
-  integer nx,ny,layers
+  double precision array(0:nx+1, 0:ny+1, layers)
+  integer nx, ny, layers
 
   ! wrap array around for periodicity
-  array(0,:,:) = array(nx,:,:)
-  array(nx+1,:,:) = array(1,:,:)
-  array(:,0,:) = array(:,ny,:)
-  array(:,ny+1,:) = array(:,1,:)
+  array(0, :, :) = array(nx, :, :)
+  array(nx+1, :, :) = array(1, :, :)
+  array(:, 0, :) = array(:, ny, :)
+  array(:, ny+1, :) = array(:, 1, :)
 
   return
 end subroutine wrap_fields_3D
@@ -1668,17 +1668,17 @@ end subroutine wrap_fields_3D
 !-----------------------------------------------------------------
 !> Wrap 2D fields around for periodic boundary conditions
 
-subroutine wrap_fields_2D(array,nx,ny)
+subroutine wrap_fields_2D(array, nx, ny)
   implicit none
 
-  double precision array(0:nx+1,0:ny+1)
-  integer nx,ny
+  double precision array(0:nx+1, 0:ny+1)
+  integer nx, ny
 
   ! wrap array around for periodicity
-  array(0,:) = array(nx,:)
-  array(nx+1,:) = array(1,:)
-  array(:,0) = array(:,ny)
-  array(:,ny+1) = array(:,1)
+  array(0, :) = array(nx, :)
+  array(nx+1, :) = array(1, :)
+  array(:, 0) = array(:, ny)
+  array(:, ny+1) = array(:, 1)
 
   return
 end subroutine wrap_fields_2D

--- a/MIM.f90
+++ b/MIM.f90
@@ -228,7 +228,7 @@ program MIM
         &wind forcings. Choose one."
     ! Stop the program
     stop
-  endif
+  end if
 
   ! Read in arrays from the input files
   call read_input_fileU(initUfile,u,0.d0,nx,ny,layers)
@@ -242,8 +242,8 @@ program MIM
     if (minval(depth) .lt. 0) then
       print *, "depths must be positive - fix this and try again"
       stop
-    endif
-  endif
+    end if
+  end if
 
   ! TODO Should probably check that bathymetry file and layer
   ! thicknesses are consistent with each other.
@@ -272,8 +272,8 @@ program MIM
     vav = 0.0
     if (.not. RedGrav) then
       etaav = 0.0
-    endif
-  endif
+    end if
+  end if
 
   ! For now enforce wetmask to have zeros around the edge.
   wetmask(0,:) = 0d0
@@ -296,13 +296,13 @@ program MIM
     ! h(:,:,k) = h(:,:,k)*wetmask(:,:)
     u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
     v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
-  enddo
+  end do
 
   ! If the winds are static, then set wind_ = base_wind_
   if (.not. UseSinusoidWind .and. .not. UseStochWind)  then
     wind_x = base_wind_x
     wind_y = base_wind_y
-  endif
+  end if
 
   ! Initialise random numbers for stochastic winds
   if (UseStochWind) then
@@ -311,7 +311,7 @@ program MIM
     call ranseed()
     ! Number of timesteps between updating the perturbed wind field.
     n_stoch_wind = int(wind_period/dt)
-  endif
+  end if
 
   if (.not. RedGrav) then
     ! Initialise arrays for pressure solver
@@ -356,7 +356,7 @@ program MIM
       print *, 'inconsistency between h and eta (in %):', &
           maxval(abs(h_norming - 1d0))*100d0
     end if
-  endif
+  end if
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !!!  Initialisation of the model STARTS HERE                              !!!
@@ -373,7 +373,7 @@ program MIM
     call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
   else
     call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
-  endif
+  end if
 
   ! Calculate relative vorticity
   call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
@@ -400,7 +400,7 @@ program MIM
     call evaluate_b_RedGrav(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec)
   else
     call evaluate_b_iso(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec,depth)
-  endif
+  end if
 
   ! Calculate relative vorticity
   call evaluate_zeta(zeta,uhalf,vhalf,nx,ny,layers,dx,dy)
@@ -435,7 +435,7 @@ program MIM
   do k = 1,layers
     u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
     v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
-  enddo
+  end do
 
   ! Wrap fields around for periodic simulations
   call wrap_fields_3D(u,nx,ny,layers)
@@ -450,7 +450,7 @@ program MIM
     call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
   else
     call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
-  endif
+  end if
 
   ! Calculate relative vorticity
   call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
@@ -478,7 +478,7 @@ program MIM
     call evaluate_b_RedGrav(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec)
   else
     call evaluate_b_iso(b,hhalf,uhalf,vhalf,nx,ny,layers,g_vec,depth)
-  endif
+  end if
 
   ! Calculate relative vorticity
   call evaluate_zeta(zeta,uhalf,vhalf,nx,ny,layers,dx,dy)
@@ -511,7 +511,7 @@ program MIM
   do k = 1,layers
     u(:,:,k) = u(:,:,k)*hfacW*wetmask(:,:)
     v(:,:,k) = v(:,:,k)*hfacS*wetmask(:,:)
-  enddo
+  end do
 
   ! Wrap fields around for periodic simulations
   call wrap_fields_3D(u,nx,ny,layers)
@@ -546,15 +546,15 @@ program MIM
             wind_beta*stoch_wind_mag)
         wind_y = base_wind_y*(wind_alpha +  &
             wind_beta*stoch_wind_mag)
-      endif
-    endif
+      end if
+    end if
 
     ! Calculate Bernoulli potential
     if (RedGrav) then
       call evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,g_vec)
     else
       call evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
-    endif
+    end if
 
     ! Calculate relative vorticity
     call evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
@@ -588,7 +588,7 @@ program MIM
     do k = 1,layers
       unew(:,:,k) = unew(:,:,k)*hfacW*wetmask(:,:)
       vnew(:,:,k) = vnew(:,:,k)*hfacS*wetmask(:,:)
-    enddo
+    end do
 
     ! Do the isopycnal layer physics
     if (.not. RedGrav) then
@@ -661,8 +661,8 @@ program MIM
       do k = 1,layers
         unew(:,:,k) = unew(:,:,k)*hfacW*wetmask(:,:)
         vnew(:,:,k) = vnew(:,:,k)*hfacS*wetmask(:,:)
-      enddo
-    endif
+      end do
+    end if
 
     ! Code to stop layers from getting too thin
     counter = 0
@@ -682,8 +682,8 @@ program MIM
               write(10,1111) n
 1111          format("layer thickness dropped below hmin at time step ", 1i10.10)
               close(unit=10)
-            endif
-          endif
+            end if
+          end if
         end do
       end do
     end do
@@ -701,7 +701,7 @@ program MIM
       vav = vav + vnew
       if (.not. RedGrav) then
         etaav = eta + etanew
-      endif
+      end if
     end if
 
     ! Shuffle arrays: old -> very old,  present -> old, new -> present
@@ -711,7 +711,7 @@ program MIM
     v = vnew
     if (.not. RedGrav) then
       eta = etanew
-    endif
+    end if
 
     ! Tendencies (old -> very old)
     dhdtveryold = dhdtold
@@ -751,7 +751,7 @@ program MIM
             form='unformatted')
         write(10) eta(1:nx,1:ny)
         close(10)
-      endif
+      end if
 
       if (DumpWind .eqv. .true.) then
         open(unit = 10, status='replace',file='output/wind_x.'//num, &
@@ -762,14 +762,14 @@ program MIM
             form='unformatted')
         write(10) wind_y(1:nx,1:ny+1)
         close(10)
-      endif
+      end if
 
       ! Check if there are NaNs in the data
       call break_if_NaN(h,nx,ny,layers,n)
       ! call break_if_NaN(u,nx,ny,layers,n)
       ! call break_if_NaN(v,nx,ny,layers,n)
 
-    endif
+    end if
 
     ! ----------------------- Average Output -----------------
     if (avwrite .eq. 0) then
@@ -801,7 +801,7 @@ program MIM
             form='unformatted')
         write(10) etaav(1:nx,1:ny)
         close(10)
-      endif
+      end if
 
       ! Check if there are NaNs in the data
       call break_if_NaN(h,nx,ny,layers,n)
@@ -814,10 +814,10 @@ program MIM
       vav = 0.0
       if (.not. RedGrav) then
         etaav = 0.0
-      endif
+      end if
       ! h2av=0.0
 
-    endif
+    end if
 
   end do
 
@@ -866,7 +866,7 @@ subroutine evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
 
   do k = 1,layers-1
     z(:,:,layers - k) = z(:,:,layers-k+1) + h(:,:,layers-k+1)
-  enddo
+  end do
 
   ! Calculate Montogmery potential
   ! The following loop is to get the baroclinic Montgomery potential
@@ -874,7 +874,7 @@ subroutine evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
   M = 0d0
   do k = 2,layers
     M(:,:,k) = M(:,:,k-1) + g_vec(k)*z(:,:,k-1)
-  enddo
+  end do
 
   b = 0d0
   ! No baroclinic pressure contribution to the first layer Bernoulli potential
@@ -1013,9 +1013,9 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
               + h(i,j-1,k)*wetmask(i,j-1)       &
               + (1d0 - wetmask(i,j-1))*h(i,j,k) & ! reflect value around boundary
               - 2*h(i,j,k))/(dy*dy) ! y-component horizontal diffusion
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
 
   ! Now do the lowest active layer, k = layers. If using reduced
   ! gravity physics, this is unconstrained and calculated as above. If
@@ -1036,13 +1036,13 @@ subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
               + h(i,j-1,layers)*wetmask(i,j-1)           &
               + (1d0 - wetmask(i,j-1))*h(i,j,layers)     & ! reflect value around boundary
               - 2*h(i,j,layers))/(dy*dy) ! y-component horizontal diffusion
-      enddo
-    enddo
+      end do
+    end do
   else if (.not. RedGrav) then ! using n-layer physics
     ! Calculate bottom layer thickness tendency to balance layers above.
     ! In the flat-bottomed case this will give the same answer.
     dhdt_GM(:,:,layers) = -sum(dhdt_GM(:,:,:layers-1),3)
-  endif
+  end if
 
   ! Now add this to the thickness tendency due to the flow field and
   ! sponge regions
@@ -1118,7 +1118,7 @@ subroutine evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, &
         if (k .eq. 1) then ! only have wind forcing on the top layer
           ! This will need refining in the event of allowing outcropping.
           dudt(i,j,k) = dudt(i,j,k) + wind_x(i,j)/(rho0*h(i,j,k)) ! wind forcing
-        endif
+        end if
         if (layers .gt. 1) then ! only evaluate vertical momentum diffusivity if more than 1 layer
           if (k .eq. 1) then ! adapt vertical momentum diffusivity for 2+ layer model -> top layer
             dudt(i,j,k) = dudt(i,j,k) - 1.0d0*ar*(u(i,j,k) - 1.0d0*u(i,j,k+1))
@@ -1127,12 +1127,12 @@ subroutine evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, &
             if (.not. RedGrav) then
               ! add bottom drag here in isopycnal version
               dudt(i,j,k) = dudt(i,j,k) - 1.0d0*botDrag*(u(i,j,k))
-            endif
+            end if
           else ! mid layer/s
             dudt(i,j,k) = dudt(i,j,k) - &
                 1.0d0*ar*(2.0d0*u(i,j,k) - 1.0d0*u(i,j,k-1) - 1.0d0*u(i,j,k+1))
-          endif
-        endif
+          end if
+        end if
       end do
     end do
   end do
@@ -1190,7 +1190,7 @@ subroutine evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, &
         if (k .eq. 1) then ! only have wind forcing on the top layer
           ! This will need refining in the event of allowing outcropping.
           dvdt(i,j,k) = dvdt(i,j,k) + wind_y(i,j)/(rho0*h(i,j,k)) ! wind forcing
-        endif
+        end if
         if (layers .gt. 1) then ! only evaluate vertical momentum diffusivity if more than 1 layer
           if (k .eq. 1) then ! adapt vertical momentum diffusivity for 2+ layer model -> top layer
             dvdt(i,j,k) = dvdt(i,j,k) - 1.0d0*ar*(v(i,j,k) - 1.0d0*v(i,j,k+1))
@@ -1199,11 +1199,11 @@ subroutine evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, &
             if (.not. RedGrav) then
               ! add bottom drag here in isopycnal version
               dvdt(i,j,k) = dvdt(i,j,k) - 1.0d0*botDrag*(v(i,j,k))
-            endif
+            end if
           else ! mid layer/s
             dvdt(i,j,k) = dvdt(i,j,k) - 1.0d0*ar*(2.0d0*v(i,j,k) - 1.0d0*v(i,j,k-1) - 1.0d0*v(i,j,k+1))
-          endif
-        endif
+          end if
+        end if
       end do
     end do
   end do
@@ -1378,7 +1378,7 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
       relax_param=1.d0/(1.d0-0.5d0*rjac**2)
     else
       relax_param=1.d0/(1.d0-0.25d0*rjac**2*relax_param)
-    endif
+    end if
 
     call wrap_fields_2D(etanew,nx,ny)
 
@@ -1390,7 +1390,7 @@ subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
       !     print *, 'change in residual less than eps of previous residual. iteration:', eps, nit
       !     return
       ! This was not a good way of exiting the solver - it would occasionally leave after 2 or 3 iterations.
-    endif
+    end if
   end do
 
   print *,'warning: maximum iterations exceeded at time step ', n
@@ -1423,7 +1423,7 @@ subroutine break_if_NaN(data,nx,ny,layers,n)
           print *, 'NaN detected'
           ! Stop the code
           stop 'Nan detected'
-        endif
+        end if
       end do
     end do
   end do
@@ -1458,16 +1458,16 @@ subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
   do j = 0,ny+1
     do i = 1,nx+1
       temp(i,j) = wetmask(i-1,j)- wetmask(i,j)
-    enddo
-  enddo
+    end do
+  end do
 
   do j = 0,ny+1
     do i = 1,nx+1
       if (temp(i,j) .ne. 0.0) then
         hfacW(i,j) = 0d0
-      endif
-    enddo
-  enddo
+      end if
+    end do
+  end do
 
   ! and now for all  western cells
   hfacW(0,:) = hfacW(nx,:)
@@ -1478,16 +1478,16 @@ subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
   do j = 0,ny+1
     do i = 0,nx
       temp(i,j) = wetmask(i,j)- wetmask(i+1,j)
-    enddo
-  enddo
+    end do
+  end do
 
   do j = 0,ny+1
     do i = 0,nx
       if (temp(i,j) .ne. 0.0) then
         hfacE(i,j) = 0d0
-      endif
-    enddo
-  enddo
+      end if
+    end do
+  end do
 
   ! and now for all  eastern cells
   hfacE(nx+1,:) = hfacE(1,:)
@@ -1498,16 +1498,16 @@ subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
   do j = 1,ny+1
     do i = 0,nx+1
       temp(i,j) = wetmask(i,j-1)- wetmask(i,j)
-    enddo
-  enddo
+    end do
+  end do
 
   do j = 1,ny+1
     do i = 0,nx+1
       if (temp(i,j) .ne. 0.0) then
         hfacS(i,j) = 0d0
-      endif
-    enddo
-  enddo
+      end if
+    end do
+  end do
 
   ! all southern cells
   hfacS(:,0) = hfacS(:,ny)
@@ -1517,16 +1517,16 @@ subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
   do j = 0,ny
     do i = 0,nx+1
       temp(i,j) = wetmask(i,j)- wetmask(i,j+1)
-    enddo
-  enddo
+    end do
+  end do
 
   do j = 0,ny
     do i = 0,nx+1
       if (temp(i,j) .ne. 0.0) then
         hfacN(i,j) = 0d0
-      endif
-    enddo
-  enddo
+      end if
+    end do
+  end do
   ! all northern cells
   hfacN(:,ny+1) = hfacN(:,1)
 
@@ -1557,8 +1557,8 @@ subroutine read_input_fileH(name,array,default,nx,ny,layers)
   else
     do k = 1,layers
       array(:,:,k) = default(k)
-    enddo
-  endif
+    end do
+  end if
 
   return
 end subroutine read_input_fileH
@@ -1586,7 +1586,7 @@ subroutine read_input_fileH_2D(name,array,default,nx,ny)
     array(:,ny+1) = array(:,1)
   else
     array = default
-  endif
+  end if
 
   return
 end subroutine read_input_fileH_2D
@@ -1614,7 +1614,7 @@ subroutine read_input_fileU(name,array,default,nx,ny,layers)
     array(:,ny+1,:) = array(:,1,:)
   else
     array = default
-  endif
+  end if
 
   return
 end subroutine read_input_fileU
@@ -1642,7 +1642,7 @@ subroutine read_input_fileV(name,array,default,nx,ny,layers)
     array(:,ny+1,:) = array(:,1,:)
   else
     array = default
-  endif
+  end if
 
   return
 end subroutine read_input_fileV

--- a/MIM.f90
+++ b/MIM.f90
@@ -773,7 +773,7 @@ program MIM
 
     ! ----------------------- Average Output -----------------
     if (avwrite .eq. 0) then
-      go to 120
+      ! OK
     else if (mod(n-1,avwrite).eq.0) then
 
       hav=hav/real(avwrite)
@@ -817,7 +817,7 @@ program MIM
       endif
       ! h2av=0.0
 
-120 endif
+    endif
 
   end do
 

--- a/MIM.f90
+++ b/MIM.f90
@@ -176,21 +176,21 @@ program MIM
   ! TODO Possibly wait until the model is split into multiple files,
   ! then hide the long unsightly code there.
 
-  NAMELIST /NUMERICS/ au, ah, ar, botDrag, dt, slip, nTimeSteps, &
+  namelist /NUMERICS/ au, ah, ar, botDrag, dt, slip, nTimeSteps, &
       dumpFreq, avFreq, hmin, maxits, freesurfFac, eps
 
-  NAMELIST /MODEL/ hmean, depthFile, H0, RedGrav
+  namelist /MODEL/ hmean, depthFile, H0, RedGrav
 
-  NAMELIST /SPONGE/ spongeHTimeScaleFile, spongeUTimeScaleFile, &
+  namelist /SPONGE/ spongeHTimeScaleFile, spongeUTimeScaleFile, &
       spongeVTimeScaleFile, spongeHfile, spongeUfile, spongeVfile
 
-  NAMELIST /PHYSICS/ g_vec, rho0
+  namelist /PHYSICS/ g_vec, rho0
 
-  NAMELIST /GRID/ dx, dy, fUfile, fVfile, wetMaskFile
+  namelist /GRID/ dx, dy, fUfile, fVfile, wetMaskFile
 
-  NAMELIST /INITIAL_CONDITONS/ initUfile, initVfile, initHfile, initEtaFile
+  namelist /INITIAL_CONDITONS/ initUfile, initVfile, initHfile, initEtaFile
 
-  NAMELIST /EXTERNAL_FORCING/ zonalWindFile, meridionalWindFile, &
+  namelist /EXTERNAL_FORCING/ zonalWindFile, meridionalWindFile, &
       UseSinusoidWind, UseStochWind, wind_alpha, wind_beta, &
       wind_period, wind_t_offset, DumpWind
 

--- a/MIM.f90
+++ b/MIM.f90
@@ -841,6 +841,8 @@ end program MIM
 !> Evaluate the Bornoulli Potential for n-layer physics.
 !! B is evaluated at the tracer point, for each grid box.
 subroutine evaluate_b_iso(b,h,u,v,nx,ny,layers,g_vec,depth)
+  implicit none
+
   ! Evaluate the baroclinic component of the Bernoulli Potential
   ! (u dot u + Montgomery potential) in the n-layer physics, at centre
   ! of grid box
@@ -899,9 +901,11 @@ end subroutine evaluate_b_iso
 ! -----------------------------------------------------------------------------
 
 subroutine evaluate_b_RedGrav(b,h,u,v,nx,ny,layers,gr)
+  implicit none
+
   ! Evaluate Bernoulli Potential at centre of grid box
   integer nx,ny,layers
-  integer i,j,k
+  integer i,j,k,l,m
   double precision h(0:nx+1,0:ny+1,layers)
   double precision u(0:nx+1,0:ny+1,layers)
   double precision v(0:nx+1,0:ny+1,layers)
@@ -941,6 +945,8 @@ end subroutine evaluate_b_RedGrav
 !> Evaluate relative vorticity at lower left grid boundary (du/dy
 !! and dv/dx are at lower left corner as well)
 subroutine evaluate_zeta(zeta,u,v,nx,ny,layers,dx,dy)
+  implicit none
+
   integer nx,ny,layers
   integer i,j,k
   double precision h(0:nx,0:ny,layers)
@@ -967,6 +973,8 @@ end subroutine evaluate_zeta
 !! dh/dt is in the centre of each grid point.
 subroutine evaluate_dhdt(dhdt, h,u,v,ah,dx,dy,nx,ny,layers, &
     spongeTimeScale,spongeH,wetmask,RedGrav)
+  implicit none
+
   ! dhdt is evaluated at the centre of the grid box
   integer nx,ny,layers
   integer i,j,k
@@ -1070,6 +1078,8 @@ end subroutine evaluate_dhdt
 subroutine evaluate_dudt(dudt, h,u,v,b,zeta,wind_x,fu, &
     au,ar,slip,dx,dy,hfacN,hfacS,nx,ny,layers,rho0, &
     spongeTimeScale,spongeU,RedGrav,botDrag)
+  implicit none
+
   ! dudt(i,j) is evaluated at the centre of the left edge of the grid
   ! box, the same place as u(i,j).
   integer nx,ny,layers
@@ -1138,6 +1148,8 @@ end subroutine evaluate_dudt
 subroutine evaluate_dvdt(dvdt, h,u,v,b,zeta,wind_y,fv, &
     au,ar,slip,dx,dy,hfacW,hfacE,nx,ny,layers,rho0, &
     spongeTimeScale,spongeV,RedGrav,botDrag)
+  implicit none
+
   ! dvdt(i,j) is evaluated at the centre of the bottom edge of the
   ! grid box, the same place as v(i,j)
   integer nx,ny,layers
@@ -1204,6 +1216,7 @@ end subroutine evaluate_dvdt
 ! -----------------------------------------------------------------------------
 !> Calculate the barotropic u velocity
 subroutine calc_baro_u(ub,u,h,eta,freesurfFac,nx,ny,layers)
+  implicit none
 
   integer nx,ny,layers
   integer i,j,k
@@ -1237,6 +1250,7 @@ end subroutine calc_baro_u
 
 !> Calculate the barotropic v velocity
 subroutine calc_baro_v(vb,v,h,eta,freesurfFac,nx,ny,layers)
+  implicit none
 
   integer nx,ny,layers
   integer i,j,k
@@ -1272,6 +1286,8 @@ end subroutine calc_baro_v
 !! timestepped with the tendencies excluding the free surface
 !! pressure gradient.
 subroutine calc_eta_star(ub,vb,eta,etastar,freesurfFac,nx,ny,dx,dy,dt)
+  implicit none
+
   integer nx,ny,layers
   integer i,j,k
   double precision eta(0:nx+1,0:ny+1)
@@ -1300,11 +1316,13 @@ end subroutine calc_eta_star
 !! pressure required to keep the barotropic flow nondivergent.
 
 subroutine SOR_solver(a,etanew,etastar,freesurfFac,nx,ny,dt,rjac,eps,maxits,n)
+  implicit none
+
   double precision a(5,nx,ny)
   double precision etanew(0:nx+1,0:ny+1)
   double precision etastar(0:nx+1,0:ny+1)
   double precision freesurfFac
-  integer nx,ny, i,j, maxits, n
+  integer nx,ny,i,j,maxits,n,nit
   double precision dt
   double precision rjac, eps
   double precision rhs(nx,ny)
@@ -1384,10 +1402,11 @@ end subroutine SOR_solver
 !> Check to see if there are any NaNs in the data field and stop the
 !! calculation if any are found.
 subroutine break_if_NaN(data,nx,ny,layers,n)
+  implicit none
 
   ! To stop the program if it detects at NaN in the variable being checked
 
-  integer nx, ny,layers,n
+  integer nx,ny,layers,n,i,j,k
   double precision data(0:nx+1, 0:ny+1,layers)
 
   do k=1,layers
@@ -1421,8 +1440,8 @@ end subroutine break_if_NaN
 !! 1 mean open
 
 subroutine calc_boundary_masks(wetmask,hfacW,hfacE,hfacS,hfacN,nx,ny)
-
   implicit none
+
   integer nx !< number of grid points in x direction
   integer ny !< number of grid points in y direction
   double precision wetmask(0:nx+1,0:ny+1)
@@ -1517,8 +1536,8 @@ end subroutine calc_boundary_masks
 ! -----------------------------------------------------------------------------
 
 subroutine read_input_fileH(name,array,default,nx,ny,layers)
-
   implicit none
+
   character(30) name
   integer nx, ny, layers, k
   double precision array(0:nx+1,0:ny+1,layers), default(layers)
@@ -1547,8 +1566,8 @@ end subroutine read_input_fileH
 ! -----------------------------------------------------------------------------
 
 subroutine read_input_fileH_2D(name,array,default,nx,ny)
-
   implicit none
+
   character(30) name
   integer nx, ny
   double precision array(0:nx+1,0:ny+1), default
@@ -1575,8 +1594,8 @@ end subroutine read_input_fileH_2D
 ! -----------------------------------------------------------------------------
 
 subroutine read_input_fileU(name,array,default,nx,ny,layers)
-
   implicit none
+
   character(30) name
   integer nx, ny,layers
   double precision array(0:nx+1,0:ny+1,layers), default
@@ -1603,8 +1622,8 @@ end subroutine read_input_fileU
 ! -----------------------------------------------------------------------------
 
 subroutine read_input_fileV(name,array,default,nx,ny,layers)
-
   implicit none
+
   character(30) name
   integer nx, ny, layers
   double precision array(0:nx+1,0:ny+1,layers), default
@@ -1632,7 +1651,6 @@ end subroutine read_input_fileV
 !> Wrap 3D fields around for periodic boundary conditions
 
 subroutine wrap_fields_3D(array,nx,ny,layers)
-
   implicit none
 
   double precision array(0:nx+1,0:ny+1,layers)
@@ -1651,7 +1669,6 @@ end subroutine wrap_fields_3D
 !> Wrap 2D fields around for periodic boundary conditions
 
 subroutine wrap_fields_2D(array,nx,ny)
-
   implicit none
 
   double precision array(0:nx+1,0:ny+1)
@@ -1672,7 +1689,6 @@ end subroutine wrap_fields_2D
 !! http://web.ph.surrey.ac.uk/fortweb/glossary/random_seed.html
 
 subroutine ranseed()
-
   implicit none
 
   ! ----- variables for portable seed setting -----

--- a/MIM.f90
+++ b/MIM.f90
@@ -217,17 +217,17 @@ program MIM
   if (UseSinusoidWind .and. UseStochWind)  then
     ! Can't use both sinusiodal and stochastic wind variation.
     ! Write a file saying so
-    OPEN(UNIT=99, FILE='errors.txt', ACTION="write", STATUS="replace", &
-        FORM="formatted")
+    open(unit=99, file='errors.txt', action="write", status="replace", &
+        form="formatted")
     write(99,*) "Can't have both stochastic and sinusoidally varying &
         &wind forcings. Choose one."
-    CLOSE(UNIT=99)
+    close(unit=99)
 
     ! Print it on the screen
     print *, "Can't have both stochastic and sinusoidally varying &
         &wind forcings. Choose one."
     ! Stop the program
-    STOP
+    stop
   endif
 
   ! Read in arrays from the input files
@@ -241,7 +241,7 @@ program MIM
     ! Check that depth is negative - it must be less than zero
     if (minval(depth) .lt. 0) then
       print *, "depths must be positive - fix this and try again"
-      STOP
+      stop
     endif
   endif
 
@@ -531,12 +531,12 @@ program MIM
   do n=1,nTimeSteps
 
     ! Time varying winds
-    if (UseSinusoidWind .eqv. .TRUE.) then
+    if (UseSinusoidWind .eqv. .true.) then
       wind_x = base_wind_x*(wind_alpha +  &
           wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
       wind_y = base_wind_y*(wind_alpha +  &
           wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
-    else if (UseStochWind .eqv. .TRUE.) then
+    else if (UseStochWind .eqv. .true.) then
       if (mod(n-1,n_stoch_wind).eq.0) then
         ! Gives a pseudorandom number in range 0 <= x < 1
         call random_number(stoch_wind_mag)
@@ -676,12 +676,12 @@ program MIM
             if (counter .eq. 1) then
               ! Write a file saying that the layer thickness value
               ! dropped below hmin and this line has been used.
-              OPEN(UNIT=10, FILE='layer thickness dropped below hmin.txt', &
-                  ACTION="write", STATUS="unknown", &
-                  FORM="formatted", POSITION = "append")
+              open(unit=10, file='layer thickness dropped below hmin.txt', &
+                  action="write", status="unknown", &
+                  form="formatted", position = "append")
               write(10,1111) n
 1111          format("layer thickness dropped below hmin at time step ", 1i10.10)
-              CLOSE(UNIT=10)
+              close(unit=10)
             endif
           endif
         end do
@@ -753,7 +753,7 @@ program MIM
         close(10)
       endif
 
-      if (DumpWind .eqv. .TRUE.) then
+      if (DumpWind .eqv. .true.) then
         open(unit = 10, status='replace',file='output/wind_x.'//num, &
             form='unformatted')
         write(10) wind_x(1:nx+1,1:ny)
@@ -821,17 +821,17 @@ program MIM
 
   end do
 
-  OPEN(UNIT=10, FILE='run_finished.txt', ACTION="write", STATUS="unknown", &
-      FORM="formatted", POSITION = "append")
+  open(unit=10, file='run_finished.txt', action="write", status="unknown", &
+      form="formatted", position = "append")
   write(10,1112) n
 1112 format( "run finished at time step ", 1i10.10)
-  CLOSE(UNIT=10)
+  close(unit=10)
 
   print *, 'Execution ended normally'
 
   stop 0
 
-END PROGRAM MIM
+end program MIM
 
 
 ! ------------------------- Beginning of the subroutines ----------------------
@@ -1395,15 +1395,15 @@ subroutine break_if_NaN(data,nx,ny,layers,n)
       do i=1,nx
         if (data(i,j,k).ne.data(i,j,k))  then
           ! write a file saying so
-          OPEN(UNIT=10, FILE='NaN detected.txt', ACTION="write", &
-              STATUS="replace", FORM="formatted")
+          open(unit=10, file='NaN detected.txt', action="write", &
+              status="replace", form="formatted")
           write(10,1000) n
 1000      format( "NaN detected at time step ", 1i10.10)
-          CLOSE(UNIT=10)
+          close(unit=10)
           ! print it on the screen
           print *, 'NaN detected'
           ! Stop the code
-          STOP 'Nan detected'
+          stop 'Nan detected'
         endif
       end do
     end do
@@ -1676,16 +1676,16 @@ subroutine ranseed()
   implicit none
 
   ! ----- variables for portable seed setting -----
-  INTEGER :: i_seed
-  INTEGER, DIMENSION(:), ALLOCATABLE :: a_seed
-  INTEGER, DIMENSION(1:8) :: dt_seed
+  integer :: i_seed
+  integer, dimension(:), allocatable :: a_seed
+  integer, dimension(1:8) :: dt_seed
   ! ----- end of variables for seed setting -----
 
   ! ----- Set up random seed portably -----
-  CALL RANDOM_SEED(size=i_seed)
-  ALLOCATE(a_seed(1:i_seed))
-  CALL RANDOM_SEED(get=a_seed)
-  CALL DATE_AND_TIME(values=dt_seed)
+  call random_seed(size=i_seed)
+  allocate(a_seed(1:i_seed))
+  call random_seed(get=a_seed)
+  call date_and_time(values=dt_seed)
   a_seed(i_seed)=dt_seed(8); a_seed(1)=dt_seed(8)*dt_seed(7)*dt_seed(6)
   call random_seed(put=a_seed)
   return

--- a/MIM.f90
+++ b/MIM.f90
@@ -406,8 +406,8 @@ program MIM
 
   ! Now calculate d/dt of u, v, h and store as dhdtveryold, dudtveryold
   ! and dvdtveryold
-  call evaluate_dhdt(dhdtveryold, hhalf, uhalf, vhalf, ah, dx, dy, nx, ny, layers, &
-      spongeHTimeScale, spongeH, wetmask, RedGrav)
+  call evaluate_dhdt(dhdtveryold, hhalf, uhalf, vhalf, ah, dx, dy, &
+      nx, ny, layers, spongeHTimeScale, spongeH, wetmask, RedGrav)
 
   call evaluate_dudt(dudtveryold, hhalf, uhalf, vhalf, b, zeta, &
       wind_x, fu, au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
@@ -483,8 +483,8 @@ program MIM
   call evaluate_zeta(zeta, uhalf, vhalf, nx, ny, layers, dx, dy)
 
   ! Now calculate d/dt of u, v, h and store as dhdtold, dudtold and dvdtold
-  call evaluate_dhdt(dhdtold, hhalf, uhalf, vhalf, ah, dx, dy, nx, ny, layers, &
-      spongeHTimeScale, spongeH, wetmask, RedGrav)
+  call evaluate_dhdt(dhdtold, hhalf, uhalf, vhalf, ah, dx, dy, &
+      nx, ny, layers, spongeHTimeScale, spongeH, wetmask, RedGrav)
   call evaluate_dudt(dudtold, hhalf, uhalf, vhalf, b, zeta, wind_x, &
       fu, au, ar, slip, dx, dy, hfacN, hfacS, nx, ny, layers, rho0, &
       spongeUTimeScale, spongeU, RedGrav, botDrag)
@@ -1200,7 +1200,8 @@ subroutine evaluate_dvdt(dvdt, h, u, v, b, zeta, wind_y, fv, &
               dvdt(i,j,k) = dvdt(i,j,k) - 1.0d0*botDrag*(v(i,j,k))
             end if
           else ! mid layer/s
-            dvdt(i,j,k) = dvdt(i,j,k) - 1.0d0*ar*(2.0d0*v(i,j,k) - 1.0d0*v(i,j,k-1) - 1.0d0*v(i,j,k+1))
+            dvdt(i,j,k) = dvdt(i,j,k) - &
+                1.0d0*ar*(2.0d0*v(i,j,k) - 1.0d0*v(i,j,k-1) - 1.0d0*v(i,j,k+1))
           end if
         end if
       end do
@@ -1314,7 +1315,8 @@ end subroutine calc_eta_star
 !! Euler timestepping for the free surface anomaly, or for the surface
 !! pressure required to keep the barotropic flow nondivergent.
 
-subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, rjac, eps, maxits, n)
+subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, &
+    rjac, eps, maxits, n)
   implicit none
 
   double precision a(5, nx, ny)

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -34,9 +34,9 @@ def compile_mim(nx, ny, layers):
     mim_path = p.join(p.dirname(self_path), "MIM.f90")
     sub.check_call(
         "cat %s " % (mim_path,) +
-        "| sed 's/^    integer, parameter :: nx =.*$/    integer, parameter :: nx = %d/'" % (nx,) +
-        "| sed 's/^    integer, parameter :: ny =.*$/    integer, parameter :: ny = %d/'" % (ny,) +
-        "| sed 's/^    integer, parameter :: layers =.*$/    integer, parameter :: layers = %d/'" % (layers,) +
+        "| sed 's/^  integer, parameter :: nx =.*$/  integer, parameter :: nx = %d/'" % (nx,) +
+        "| sed 's/^  integer, parameter :: ny =.*$/  integer, parameter :: ny = %d/'" % (ny,) +
+        "| sed 's/^  integer, parameter :: layers =.*$/  integer, parameter :: layers = %d/'" % (layers,) +
         "> MIM.f90", shell=True)
     sub.check_call(["gfortran", "-Ofast", "MIM.f90", "-o", "MIM"])
 


### PR DESCRIPTION
Summary of Fortran code style enforced:
- Indentation of two spaces for all block constructs.
- Four-space indentation of continuation lines (with some exceptions to clarify structure of long algebraic expressions).
- Lines should have no trailing whitespace.
- The last line in the file should have one newline, and no additional blank lines.
- Lines should be < 80 characters wide, but I was not successful in breaking all over-long lines.  The remainder are predominantly line comments that I did not wish to move off their line, not knowing what exactly they referred to.
- Spell language keywords in lower case.
- All subroutines should declare `implicit none`
  - (Enforcing this required explicitly declaring the handful of variables that were implicit.)
- Spell block terminators `end do`, `end if`, and `end subroutine <name>`, not `enddo` or `endif`.  (Emacs was kind enough to automatically insert the subroutine names.)
- Commas should be followed by whitespace, as in written natural languages.
  - (Exception: array subscripts in dense algebraic expressions, as they should be compact enough that the eye groups the array element as one thing.)
- The equal sign should be offset with spaces when it means assignment, and not offset when it means value for keyword argument.

Confirmed, using the test suite, that output remains bit-for-bit identical with the version preceding this PR, on my machine.

Fixes #17 as stated, though this is by no means a complete style guide.