### PR TITLE
Thickness consistency

### DIFF
--- a/MIM.f90
+++ b/MIM.f90
@@ -125,6 +125,7 @@ program MIM
   double precision :: eps, rjac
   double precision :: freesurfFac
   double precision :: h_norming(0:nx+1, 0:ny+1)
+  double precision :: thickness_error
 
   ! Model
   double precision :: hmean(layers)
@@ -177,7 +178,8 @@ program MIM
   ! then hide the long unsightly code there.
 
   namelist /NUMERICS/ au, ah, ar, botDrag, dt, slip, nTimeSteps, &
-      dumpFreq, avFreq, hmin, maxits, freesurfFac, eps
+      dumpFreq, avFreq, hmin, maxits, freesurfFac, eps, &
+      thickness_error
 
   namelist /MODEL/ hmean, depthFile, H0, RedGrav
 
@@ -351,7 +353,7 @@ program MIM
       h(:, :, k) = h(:, :, k) * h_norming
     end do
 
-    if (maxval(abs(h_norming - 1d0)).gt. 1e-2) then
+    if (maxval(abs(h_norming - 1d0)).gt. thickness_error) then
       print *, 'inconsistency between h and eta (in %):', &
           maxval(abs(h_norming - 1d0))*100d0
     end if
@@ -645,8 +647,8 @@ program MIM
         hnew(:, :, k) = hnew(:, :, k) * h_norming
       end do
 
-      if (maxval(abs(h_norming - 1d0)) .gt. 1e-2) then
-        print *, 'substantial inconsistency between h and eta (in %).', &
+      if (maxval(abs(h_norming - 1d0)) .gt. thickness_error) then
+        print *, 'inconsistency between h and eta (in %).', &
             maxval(abs(h_norming - 1d0))*100
       end if
 

--- a/parameters.in
+++ b/parameters.in
@@ -32,6 +32,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,1600.,

--- a/test/beta_plane_bump/parameters.in
+++ b/test/beta_plane_bump/parameters.in
@@ -32,6 +32,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,1600.,

--- a/test/beta_plane_bump_red_grav/parameters.in
+++ b/test/beta_plane_bump_red_grav/parameters.in
@@ -31,6 +31,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,

--- a/test/beta_plane_gyre/parameters.in
+++ b/test/beta_plane_gyre/parameters.in
@@ -32,6 +32,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 600.,1400.,

--- a/test/beta_plane_gyre_red_grav/parameters.in
+++ b/test/beta_plane_gyre_red_grav/parameters.in
@@ -31,6 +31,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,

--- a/test/f_plane/parameters.in
+++ b/test/f_plane/parameters.in
@@ -32,6 +32,7 @@
  maxits = 500,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,1600.,

--- a/test/f_plane_red_grav/parameters.in
+++ b/test/f_plane_red_grav/parameters.in
@@ -31,6 +31,7 @@
  maxits = 1000,
  eps = 1e-2,
  freesurfFac = 0.,
+ thickness_error = 1e-2,
  /
  &MODEL
  hmean = 400.,


### PR DESCRIPTION
The model prints a warning if the inconsistency between the summed layer thicknesses and the depth of the domain is above a certain threshold. This pull request adds the functionality for the user to specify the threshold. The default value is set at 1%.

This was discussed in #14 .