### PR TITLE
Give wind magnitude as an input time series

### DIFF
--- a/MIM.f90
+++ b/MIM.f90
@@ -258,6 +258,9 @@ program MIM
   call read_input_file_time_series(wind_mag_time_series_file, &
    wind_mag_time_series, 1.d0, nTimeSteps)
 
+  wind_x = base_wind_x*wind_mag_time_series(1)
+  wind_y = base_wind_y*wind_mag_time_series(1)
+
   call read_input_fileH(spongeHTimeScaleFile, spongeHTimeScale, &
       zeros, nx, ny, layers)
   call read_input_fileH(spongeHfile, spongeH, hmean, nx, ny, layers)
@@ -552,6 +555,9 @@ program MIM
     !         wind_beta*stoch_wind_mag)
     !   end if
     ! end if
+
+    wind_x = base_wind_x*wind_mag_time_series(n)
+    wind_y = base_wind_y*wind_mag_time_series(n)
 
     ! Calculate Bernoulli potential
     if (RedGrav) then

--- a/MIM.f90
+++ b/MIM.f90
@@ -150,6 +150,9 @@ program MIM
   double precision :: wind_alpha, wind_beta, wind_period, wind_t_offset
   integer :: n_stoch_wind
   double precision :: stoch_wind_mag
+  character(30) :: wind_mag_time_series_file
+  double precision, dimension(:), allocatable :: wind_mag_time_series
+
 
   ! Sponge
   double precision :: spongeHTimeScale(0:nx+1, 0:ny+1, layers)

--- a/MIM.f90
+++ b/MIM.f90
@@ -255,6 +255,8 @@ program MIM
 
   call read_input_fileU(zonalWindFile, base_wind_x, 0.d0, nx, ny, 1)
   call read_input_fileV(meridionalWindFile, base_wind_y, 0.d0, nx, ny, 1)
+  
+  allocate(wind_mag_time_series(nTimeSteps))
   call read_input_file_time_series(wind_mag_time_series_file, &
    wind_mag_time_series, 1.d0, nTimeSteps)
 

--- a/MIM.f90
+++ b/MIM.f90
@@ -144,12 +144,12 @@ program MIM
   double precision :: wind_y(0:nx+1, 0:ny+1)
   double precision :: base_wind_x(0:nx+1, 0:ny+1)
   double precision :: base_wind_y(0:nx+1, 0:ny+1)
-  logical :: UseSinusoidWind
-  logical :: UseStochWind
+  ! logical :: UseSinusoidWind
+  ! logical :: UseStochWind
   logical :: DumpWind
-  double precision :: wind_alpha, wind_beta, wind_period, wind_t_offset
-  integer :: n_stoch_wind
-  double precision :: stoch_wind_mag
+  ! double precision :: wind_alpha, wind_beta, wind_period, wind_t_offset
+  ! integer :: n_stoch_wind
+  ! double precision :: stoch_wind_mag
   character(30) :: wind_mag_time_series_file
   double precision, dimension(:), allocatable :: wind_mag_time_series
 
@@ -193,9 +193,9 @@ program MIM
   namelist /INITIAL_CONDITONS/ initUfile, initVfile, initHfile, initEtaFile
 
   namelist /EXTERNAL_FORCING/ zonalWindFile, meridionalWindFile, &
-      UseSinusoidWind, UseStochWind, wind_alpha, wind_beta, &
-      wind_period, wind_t_offset, DumpWind, &
-      wind_mag_time_series_file
+      ! UseSinusoidWind, UseStochWind, wind_alpha, wind_beta, &
+      ! wind_period, wind_t_offset, 
+      DumpWind, wind_mag_time_series_file
 
   open(unit=8, file="parameters.in", status='OLD', recl=80)
   read(unit=8, nml=NUMERICS)
@@ -215,22 +215,22 @@ program MIM
   ! Zero vector - for internal use only
   zeros = 0d0
 
-  ! Check that time-dependent forcing flags have been set correctly
-  if (UseSinusoidWind .and. UseStochWind)  then
-    ! Can't use both sinusiodal and stochastic wind variation.
-    ! Write a file saying so
-    open(unit=99, file='errors.txt', action="write", status="replace", &
-        form="formatted")
-    write(99, *) "Can't have both stochastic and sinusoidally varying &
-        &wind forcings. Choose one."
-    close(unit=99)
+  ! ! Check that time-dependent forcing flags have been set correctly
+  ! if (UseSinusoidWind .and. UseStochWind)  then
+  !   ! Can't use both sinusiodal and stochastic wind variation.
+  !   ! Write a file saying so
+  !   open(unit=99, file='errors.txt', action="write", status="replace", &
+  !       form="formatted")
+  !   write(99, *) "Can't have both stochastic and sinusoidally varying &
+  !       &wind forcings. Choose one."
+  !   close(unit=99)
 
-    ! Print it on the screen
-    print *, "Can't have both stochastic and sinusoidally varying &
-        &wind forcings. Choose one."
-    ! Stop the program
-    stop
-  end if
+  !   ! Print it on the screen
+  !   print *, "Can't have both stochastic and sinusoidally varying &
+  !       &wind forcings. Choose one."
+  !   ! Stop the program
+  !   stop
+  ! end if
 
   ! Read in arrays from the input files
   call read_input_fileU(initUfile, u, 0.d0, nx, ny, layers)
@@ -255,10 +255,10 @@ program MIM
 
   call read_input_fileU(zonalWindFile, base_wind_x, 0.d0, nx, ny, 1)
   call read_input_fileV(meridionalWindFile, base_wind_y, 0.d0, nx, ny, 1)
-  
+
   allocate(wind_mag_time_series(nTimeSteps))
   call read_input_file_time_series(wind_mag_time_series_file, &
-   wind_mag_time_series, 1.d0, nTimeSteps)
+      wind_mag_time_series, 1.d0, nTimeSteps)
 
   wind_x = base_wind_x*wind_mag_time_series(1)
   wind_y = base_wind_y*wind_mag_time_series(1)

--- a/MIM.f90
+++ b/MIM.f90
@@ -1639,6 +1639,27 @@ subroutine read_input_fileV(name, array, default, nx, ny, layers)
   return
 end subroutine read_input_fileV
 
+! -----------------------------------------------------------------------------
+
+subroutine read_input_file_time_series(name, array, default, nTimeSteps)
+  implicit none
+
+  character(30) name
+  integer nTimeSteps
+  double precision array(nTimeSteps), default
+
+  if (name.ne.'') then
+    open(unit=10, form='unformatted', file=name)
+    read(10) array
+    close(10)
+
+  else
+    array = default
+  end if
+
+  return
+end subroutine read_input_file_time_series
+
 !-----------------------------------------------------------------
 !> Wrap 3D fields around for periodic boundary conditions
 

--- a/MIM.f90
+++ b/MIM.f90
@@ -194,7 +194,8 @@ program MIM
 
   namelist /EXTERNAL_FORCING/ zonalWindFile, meridionalWindFile, &
       UseSinusoidWind, UseStochWind, wind_alpha, wind_beta, &
-      wind_period, wind_t_offset, DumpWind
+      wind_period, wind_t_offset, DumpWind, &
+      wind_mag_time_series_file
 
   open(unit=8, file="parameters.in", status='OLD', recl=80)
   read(unit=8, nml=NUMERICS)
@@ -254,6 +255,8 @@ program MIM
 
   call read_input_fileU(zonalWindFile, base_wind_x, 0.d0, nx, ny, 1)
   call read_input_fileV(meridionalWindFile, base_wind_y, 0.d0, nx, ny, 1)
+  call read_input_file_time_series(wind_mag_time_series_file, &
+   wind_mag_time_series, 1.d0, nTimeSteps)
 
   call read_input_fileH(spongeHTimeScaleFile, spongeHTimeScale, &
       zeros, nx, ny, layers)

--- a/MIM.f90
+++ b/MIM.f90
@@ -302,20 +302,20 @@ program MIM
     v(:, :, k) = v(:, :, k) * hfacS * wetmask(:, :)
   end do
 
-  ! If the winds are static, then set wind_ = base_wind_
-  if (.not. UseSinusoidWind .and. .not. UseStochWind)  then
-    wind_x = base_wind_x
-    wind_y = base_wind_y
-  end if
+  ! ! If the winds are static, then set wind_ = base_wind_
+  ! if (.not. UseSinusoidWind .and. .not. UseStochWind)  then
+  !   wind_x = base_wind_x
+  !   wind_y = base_wind_y
+  ! end if
 
-  ! Initialise random numbers for stochastic winds
-  if (UseStochWind) then
-    ! This ensures a different series of random numbers each time the
-    ! model is run.
-    call ranseed()
-    ! Number of timesteps between updating the perturbed wind field.
-    n_stoch_wind = int(wind_period/dt)
-  end if
+  ! ! Initialise random numbers for stochastic winds
+  ! if (UseStochWind) then
+  !   ! This ensures a different series of random numbers each time the
+  !   ! model is run.
+  !   call ranseed()
+  !   ! Number of timesteps between updating the perturbed wind field.
+  !   n_stoch_wind = int(wind_period/dt)
+  ! end if
 
   if (.not. RedGrav) then
     ! Initialise arrays for pressure solver
@@ -534,24 +534,24 @@ program MIM
 
   do n = 1, nTimeSteps
 
-    ! Time varying winds
-    if (UseSinusoidWind .eqv. .true.) then
-      wind_x = base_wind_x*(wind_alpha +  &
-          wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
-      wind_y = base_wind_y*(wind_alpha +  &
-          wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
-    else if (UseStochWind .eqv. .true.) then
-      if (mod(n-1, n_stoch_wind).eq.0) then
-        ! Gives a pseudorandom number in range 0 <= x < 1
-        call random_number(stoch_wind_mag)
-        ! Convert to -1 <= x < 1
-        stoch_wind_mag = (stoch_wind_mag - 0.5d0)*2d0
-        wind_x = base_wind_x*(wind_alpha +  &
-            wind_beta*stoch_wind_mag)
-        wind_y = base_wind_y*(wind_alpha +  &
-            wind_beta*stoch_wind_mag)
-      end if
-    end if
+    ! ! Time varying winds
+    ! if (UseSinusoidWind .eqv. .true.) then
+    !   wind_x = base_wind_x*(wind_alpha +  &
+    !       wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
+    !   wind_y = base_wind_y*(wind_alpha +  &
+    !       wind_beta*sin(((2d0*pi*n*dt)/wind_period) - wind_t_offset))
+    ! else if (UseStochWind .eqv. .true.) then
+    !   if (mod(n-1, n_stoch_wind).eq.0) then
+    !     ! Gives a pseudorandom number in range 0 <= x < 1
+    !     call random_number(stoch_wind_mag)
+    !     ! Convert to -1 <= x < 1
+    !     stoch_wind_mag = (stoch_wind_mag - 0.5d0)*2d0
+    !     wind_x = base_wind_x*(wind_alpha +  &
+    !         wind_beta*stoch_wind_mag)
+    !     wind_y = base_wind_y*(wind_alpha +  &
+    !         wind_beta*stoch_wind_mag)
+    !   end if
+    ! end if
 
     ! Calculate Bernoulli potential
     if (RedGrav) then

--- a/parameters.in
+++ b/parameters.in
@@ -70,12 +70,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = 'input/wind_x.bin',
  meridionalWindFile = 'input/wind_y.bin', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /

--- a/parameters.in
+++ b/parameters.in
@@ -77,6 +77,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/beta_plane_bump/parameters.in
+++ b/test/beta_plane_bump/parameters.in
@@ -76,6 +76,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/beta_plane_bump/parameters.in
+++ b/test/beta_plane_bump/parameters.in
@@ -69,12 +69,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = '',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /

--- a/test/beta_plane_bump_red_grav/parameters.in
+++ b/test/beta_plane_bump_red_grav/parameters.in
@@ -75,6 +75,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/beta_plane_bump_red_grav/parameters.in
+++ b/test/beta_plane_bump_red_grav/parameters.in
@@ -68,12 +68,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = '',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /

--- a/test/beta_plane_gyre/parameters.in
+++ b/test/beta_plane_gyre/parameters.in
@@ -70,12 +70,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = 'input/wind_x.bin',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .TRUE.,
  wind_mag_time_series_file = '',
  /

--- a/test/beta_plane_gyre/parameters.in
+++ b/test/beta_plane_gyre/parameters.in
@@ -77,6 +77,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .TRUE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/beta_plane_gyre_red_grav/parameters.in
+++ b/test/beta_plane_gyre_red_grav/parameters.in
@@ -68,12 +68,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = 'input/wind_x.bin',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /

--- a/test/beta_plane_gyre_red_grav/parameters.in
+++ b/test/beta_plane_gyre_red_grav/parameters.in
@@ -75,6 +75,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/f_plane/parameters.in
+++ b/test/f_plane/parameters.in
@@ -76,6 +76,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/f_plane/parameters.in
+++ b/test/f_plane/parameters.in
@@ -69,12 +69,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = '',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /

--- a/test/f_plane_red_grav/parameters.in
+++ b/test/f_plane_red_grav/parameters.in
@@ -75,6 +75,7 @@
  wind_period = 3e6,
  wind_t_offset = 0d0,
  DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
  /
 ! input/initH.bin
 ! 

--- a/test/f_plane_red_grav/parameters.in
+++ b/test/f_plane_red_grav/parameters.in
@@ -68,12 +68,6 @@
  &EXTERNAL_FORCING
  zonalWindFile = '',
  meridionalWindFile = '', 
- UseSinusoidWind = .FALSE.,
- UseStochWind = .FALSE.,
- wind_alpha = 1d0,
- wind_beta = 0.5d0,
- wind_period = 3e6,
- wind_t_offset = 0d0,
  DumpWind = .FALSE.,
  wind_mag_time_series_file = '',
  /


### PR DESCRIPTION
This pull request removes the fortran code for varying the wind stress magnitude and instead takes a time series of length `nTimeSteps` as an input. If no input file is specified the default is an array filled with ones. 

The `DumpWind` variable has been left in the model since it may be of use when debugging simulations - it could be used to verify that the wind stress magnitude is varying as expected.

This obviates both #8 and #9, and closes #21.

Since the number of time steps is set in `parameters.in` and not in the Fortran source code, the wind stress magnitude array is an allocatable array. Thus it provides something of a recipe for us to follow when we implement #12.