### PR TITLE
Travis valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install: "pip install scipy"
 
 script:
   - gfortran -Wall -Werror MIM.f90
-  - pytest
+  - MIM_TEST_VALGRIND_ALL=1 pytest
 
 after_success:

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -47,7 +47,7 @@ def run_experiment(write_input, nx, ny, layers, valgrind=False):
     with working_directory("input"):
         write_input(nx, ny, layers)
     compile_mim(nx, ny, layers)
-    if valgrind:
+    if valgrind or 'MIM_TEST_VALGRIND_ALL' in os.environ:
         sub.check_call(["valgrind", "./MIM"])
     else:
         sub.check_call(["./MIM"])


### PR DESCRIPTION
Tweak the current test suite so that Travis executes all the mim runs under Valgrind to check for memory consistency.  Fixes #37, specifically the content it has above and beyond #6.