### PR TITLE
Profiling 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 # The MIM executable
 /MIM
 /MIM_test
+/MIM_prof
+
+# Profiling
+gmon.out
 
 # Distribution / packaging
 .Python

--- a/MIM.f90
+++ b/MIM.f90
@@ -1334,13 +1334,14 @@ subroutine SOR_solver(a, etanew, etastar, freesurfFac, nx, ny, dt, &
     rjac, eps, maxits, n)
   implicit none
 
-  double precision a(5, nx, ny)
-  double precision etanew(0:nx+1, 0:ny+1)
-  double precision etastar(0:nx+1, 0:ny+1)
-  double precision freesurfFac
-  integer nx, ny, i, j, maxits, n, nit
-  double precision dt
-  double precision rjac, eps
+  double precision, intent(in)  :: a(5, nx, ny)
+  double precision, intent(out) :: etanew(0:nx+1, 0:ny+1)
+  double precision, intent(in)  :: etastar(0:nx+1, 0:ny+1)
+  double precision, intent(in)  :: freesurfFac
+  integer, intent(in) :: nx, ny, maxits, n
+  double precision, intent(in) :: dt
+  double precision, intent(in) :: rjac, eps
+  integer i, j, nit
   double precision rhs(nx, ny)
   double precision res(nx, ny)
   double precision norm, norm0

--- a/MIM.f90
+++ b/MIM.f90
@@ -1121,8 +1121,8 @@ subroutine evaluate_dudt(dudt, h, u, v, b, zeta, wind_x, fu, &
   dudt = 0d0
 
   do k = 1, layers
-    do i = 1, nx
-      do j = 1, ny
+    do j = 1, ny
+      do i = 1, nx
         dudt(i,j,k) = au*(u(i+1,j,k)+u(i-1,j,k)-2.0d0*u(i,j,k))/(dx*dx) & ! x-component
             + au*(u(i,j+1,k)+u(i,j-1,k)-2.0d0*u(i,j,k) &
               ! boundary conditions

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ MIM: MIM.f90 Makefile
 
 MIM_test: MIM.f90 Makefile
 	gfortran -g -O1 -fcheck=all $< -o $@
+
+MIM_prof: MIM.f90 Makefile
+	gfortran -g -pg -Ofast $< -o $@

--- a/benchmarks/profile.py
+++ b/benchmarks/profile.py
@@ -12,12 +12,31 @@ def do_red_grav(nx):
         opt.run_experiment(
             opt.write_input_beta_plane_bump_red_grav, nx, nx, 1, "MIM_prof")
 
+def do_n_layer(nx):
+    with opt.working_directory(p.join(self_path, "beta_plane_bump")):
+        opt.run_experiment(
+            opt.write_input_beta_plane_bump, nx, nx, 2, "MIM_prof")
+
 def main():
     nx = 100
-    if len(sys.argv) > 1:
-        nx = int(sys.argv[1])
-    do_red_grav(nx)
-    outpath = p.join(self_path, "beta_plane_bump_red_grav", "gmon.out")
+    red_grav = True
+    for arg in sys.argv[1:]:
+        if arg.lower() == "red-grav":
+            red_grav = True
+        elif arg.lower() == "n-layer":
+            red_grav = False
+        else:
+            nx = int(arg)
+    if red_grav:
+        print "Profiling a reduced gravity configuration" \
+            + " of size %dx%dx1 by 502 time steps." % (nx, nx)
+        do_red_grav(nx)
+        outpath = p.join(self_path, "beta_plane_bump_red_grav", "gmon.out")
+    else:
+        print "Profiling an n-layer configuration" \
+            + " of size %dx%dx2 by 502 time steps." % (nx, nx)
+        do_n_layer(nx)
+        outpath = p.join(self_path, "beta_plane_bump", "gmon.out")
     print "Inspect %s,\nfor example with gprof MIM_prof %s" % (outpath, outpath)
 
 if __name__ == '__main__':

--- a/benchmarks/profile.py
+++ b/benchmarks/profile.py
@@ -1,0 +1,24 @@
+import os.path as p
+
+self_path = p.dirname(p.abspath(__file__))
+root_path = p.dirname(self_path)
+
+import sys
+sys.path.append(p.join(root_path, 'test'))
+import output_preservation_test as opt
+
+def do_red_grav(nx):
+    with opt.working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
+        opt.run_experiment(
+            opt.write_input_beta_plane_bump_red_grav, nx, nx, 1, "MIM_prof")
+
+def main():
+    nx = 100
+    if len(sys.argv) > 1:
+        nx = int(sys.argv[1])
+    do_red_grav(nx)
+    outpath = p.join(self_path, "beta_plane_bump_red_grav", "gmon.out")
+    print "Inspect %s,\nfor example with gprof MIM_prof %s" % (outpath, outpath)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
First-pass profiling.  This PR is a smallish grab-bag of profile-related changes
- Define a Python script for easy profiling in the beta plane bump configuration.
- Annotate SOR_solver with intents so I understand it better.
- Profiler-driven loop nesting order change in `evaluate_dudt`, which seems to be worth a 21% end-to-end speedup in the reduced-gravity configuration.