### PR TITLE
Pysics tests

### DIFF
--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -186,6 +186,7 @@ def test_f_plane_red_grav():
     with working_directory(p.join(self_path, "f_plane_red_grav")):
         run_experiment(write_input_f_plane_red_grav, 10, 10, 1)
         assert_outputs_close(10, 10, 1, 1e-15)
+        assert_volume_conservation(10, 10, 1, 1e-5)
 
 def write_input_f_plane(nx, ny, layers):
     assert layers == 2
@@ -201,6 +202,7 @@ def test_f_plane():
     with working_directory(p.join(self_path, "f_plane")):
         run_experiment(write_input_f_plane, 10, 10, 2)
         assert_outputs_close(10, 10, 2, 1e-15)
+        assert_volume_conservation(10, 10, 2, 1e-5)
 
 def write_input_beta_plane_bump_red_grav(nx, ny, layers):
     assert layers == 1
@@ -220,6 +222,7 @@ def test_gaussian_bump_red_grav():
     with working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
         run_experiment(write_input_beta_plane_bump_red_grav, 10, 10, 1)
         assert_outputs_close(10, 10, 1, 1.5e-13)
+        assert_volume_conservation(10, 10, 1, 1e-5)
 
 def write_input_beta_plane_bump(nx, ny, layers):
     assert layers == 2
@@ -241,6 +244,7 @@ def test_gaussian_bump():
     with working_directory(p.join(self_path, "beta_plane_bump")):
         run_experiment(write_input_beta_plane_bump, 10, 10, 2)
         assert_outputs_close(10, 10, 2, 2e-13)
+        assert_volume_conservation(10, 10, 2, 1e-5)
 
 def write_input_beta_plane_gyre_red_grav(nx, ny, layers):
     assert layers == 1
@@ -263,6 +267,7 @@ def test_beta_plane_gyre_red_grav():
     with working_directory(p.join(self_path, "beta_plane_gyre_red_grav")):
         run_experiment(write_input_beta_plane_gyre_red_grav, 10, 10, 1, valgrind=True)
         assert_outputs_close(10, 10, 1, 2e-13)
+        assert_volume_conservation(10, 10, 1, 1e-5)
 
 def write_input_beta_plane_gyre(nx, ny, layers):
     assert layers == 2
@@ -289,3 +294,4 @@ def test_beta_plane_gyre():
     with working_directory(p.join(self_path, "beta_plane_gyre")):
         run_experiment(write_input_beta_plane_gyre, 10, 10, 2, valgrind=True)
         assert_outputs_close(10, 10, 2, 3e-12)
+        assert_volume_conservation(10, 10, 2, 1e-5)

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -4,6 +4,8 @@ import os.path as p
 import subprocess as sub
 import time
 
+import glob
+
 import numpy as np
 from scipy.io import FortranFile
 
@@ -124,6 +126,22 @@ def assert_outputs_close(nx, ny, layers, rtol):
         ans = interpret_mim_raw_file(p.join("output/", outfile), nx, ny, layers)
         good_ans = interpret_mim_raw_file(p.join("good-output/", outfile), nx, ny, layers)
         assert np.amax(array_relative_error(ans, good_ans)) < rtol
+
+def assert_volume_conservation(nx,ny,layers,rtol):
+    hfiles = sorted(glob.glob("output/snap.h.*"))
+
+    h_0 = interpret_mim_raw_file(hfiles[0], nx, ny, layers)
+    h_final = interpret_mim_raw_file(hfiles[-1], nx, ny, layers)
+
+    volume_0 = np.zeros((layers))
+    volume_final = np.zeros((layers))
+
+    for k in xrange(layers):
+        volume_0[k] = np.sum(h_0[:,:,k])
+        volume_final[k] = np.sum(h_final[:,:,k])
+
+        assert np.abs((volume_0[k] - volume_final[k])/volume_0[k]) < rtol
+
 
 ### Input construction helpers
 

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -12,6 +12,7 @@ root_path = p.dirname(self_path)
 
 import sys
 sys.path.append(p.join(root_path, 'test'))
+<<<<<<< HEAD
 import output_preservation_test as opt
 
 
@@ -147,3 +148,6 @@ def write_f_plane_red_grav_init_u_input(nx,ny,layers):
         plt.pcolormesh(init_u)
         plt.colorbar()
         plt.savefig('init_u.png')
+=======
+import output_preservation_test as opt
+>>>>>>> parent of 03580ac... functions to write inputs

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -1,0 +1,15 @@
+import os.path as p
+
+import glob
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import MIMutils as mim
+
+self_path = p.dirname(p.abspath(__file__))
+root_path = p.dirname(self_path)
+
+import sys
+sys.path.append(p.join(root_path, 'test'))
+import output_preservation_test as opt

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -15,6 +15,109 @@ sys.path.append(p.join(root_path, 'test'))
 import output_preservation_test as opt
 
 
+
+def f_plane_red_grav_init_u_test():
+    nx = 100
+    ny = 100
+    layers = 1
+
+    dx = 10e3
+    dy = 10e3
+
+    grid = mim.Grid(nx,ny,dx,dy)
+
+    rho0 = 1035.
+
+    dt = 60.
+
+    with opt.working_directory(p.join(self_path, "physics_tests/f_plane_red_grav_init_u")):
+        mim_exec = "MIM_test"
+        opt.run_experiment(
+              write_f_plane_red_grav_init_u_input, nx, ny, layers, mim_exec)
+
+        hfiles = sorted(glob.glob("output/snap.h.*"))
+        ufiles = sorted(glob.glob("output/snap.u.*"))
+        vfiles = sorted(glob.glob("output/snap.v.*"))
+
+
+        model_iteration = np.zeros(len(hfiles))
+
+        energy = np.zeros(len(hfiles))
+        energy_expected = np.zeros(len(hfiles))
+
+        momentum = np.zeros(len(hfiles))
+
+        volume = np.zeros(len(hfiles))
+
+        for counter,ufile in enumerate(ufiles):
+
+            h = opt.interpret_mim_raw_file(hfiles[counter], nx, ny, layers)
+            u = opt.interpret_mim_raw_file(ufile, nx, ny, layers)
+            v = opt.interpret_mim_raw_file(vfiles[counter], nx, ny, layers)
+
+            model_iteration[counter] = float(ufile[-10:])
+
+            # plt.figure()
+            # plt.pcolormesh(grid.xp1,grid.y,u[:,:,0].transpose())
+            # plt.colorbar()
+            # plt.savefig('u.{0}.png'.format(ufile[-10:]),dpi=150)
+            # plt.close()
+
+            # plt.figure()
+            # plt.pcolormesh(grid.x,grid.y,h[:,:,0].transpose())
+            # plt.colorbar()
+            # plt.savefig('h.{0}.png'.format(ufile[-10:]),dpi=150)
+            # plt.close()
+
+            energy[counter] = (dx * dy * rho0 * (np.sum(np.absolute(h * ((u[1:,...]**2 + u[:-1,...]**2))/4.)/2.) + np.sum(np.absolute(h * ((v[:,1:,:]**2 + v[:,:-1,:]**2))/4.)/2.)) +  
+              dx * dy * rho0 * 0.01 * np.sum(np.absolute(h - 400.)))
+
+            momentum[counter] = dx * dy * rho0 * (np.sum(np.absolute(h * (u[1:,...] + u[:-1,...])/2.)) + np.sum(np.absolute(h * (v[:,1:,:] + v[:,:-1,:])/2.)))
+
+            volume[counter] = np.sum(h)
+        
+        opt.assert_volume_conservation(nx, ny, layers, 1e-9)
+
+        init_u = np.zeros((nx+1,ny),dtype=np.float64)
+        init_u[50,50] = 0.2
+
+        energy_expected[:] = (dx * dy * rho0 * np.sum(np.absolute(400. * ((init_u[1:,...] + init_u[:-1,...])**2)/2.)/2.))
+
+
+        #assert np.amax(array_relative_error(ans, good_ans)) < rtol
+        plt.figure()
+        #plt.plot(model_iteration, energy_expected, '-o', alpha=0.5,
+        #        label='Expected energy')
+        plt.plot(model_iteration, energy, '-*', alpha=0.5,
+                label='simulated energy')
+        plt.legend()
+        plt.xlabel('time step')
+        plt.ylabel('energy')
+        plt.savefig('f_plane_energy_test.png', dpi=150)
+
+        plt.figure()
+        plt.plot(model_iteration,energy/energy_expected)
+        plt.xlabel('timestep')
+        plt.ylabel('simulated/expected')
+        plt.savefig('ratio.png')
+        plt.close()
+
+        plt.figure()
+        plt.plot(model_iteration,volume)
+        plt.ylabel('Volume')
+        plt.xlabel('timestep')
+        plt.savefig('volume.png')
+        plt.close()
+
+        plt.figure()
+        plt.plot(model_iteration, momentum, '-*', alpha=0.5,
+                label='simulated momentum')
+        plt.legend()
+        plt.xlabel('time step')
+        plt.ylabel('momentum')
+        plt.savefig('f_plane_momentum_test.png', dpi=150)
+
+
 def write_f_plane_red_grav_wind_input(nx,ny,layers):
     opt.write_f_plane(nx, ny, 10e-4)
     opt.write_rectangular_pool(nx, ny)

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -13,3 +13,34 @@ root_path = p.dirname(self_path)
 import sys
 sys.path.append(p.join(root_path, 'test'))
 import output_preservation_test as opt
+
+
+def write_f_plane_red_grav_wind_input(nx,ny,layers):
+    opt.write_f_plane(nx, ny, 10e-4)
+    opt.write_rectangular_pool(nx, ny)
+    with opt.fortran_file('initH.bin', 'w') as f:
+        f.write_record(np.ones((nx, ny,layers), dtype=np.float64) * 400)
+    with opt.fortran_file('wind_x.bin','w') as f:
+        wind_x = np.zeros((ny,nx+1),dtype=np.float64)
+        wind_x[50,50] = 0.2
+        f.write_record(wind_x)
+
+        plt.figure()
+        plt.pcolormesh(wind_x)
+        plt.colorbar()
+        plt.savefig('wind_x.png')
+
+def write_f_plane_red_grav_init_u_input(nx,ny,layers):
+    opt.write_f_plane(nx, ny, 10e-4)
+    opt.write_rectangular_pool(nx, ny)
+    with opt.fortran_file('initH.bin', 'w') as f:
+        f.write_record(np.ones((nx, ny,layers), dtype=np.float64) * 400)
+    with opt.fortran_file('init_u.bin','w') as f:
+        init_u = np.zeros((ny,nx+1),dtype=np.float64)
+        init_u[50,50] = 0.2
+        f.write_record(init_u)
+
+        plt.figure()
+        plt.pcolormesh(init_u)
+        plt.colorbar()
+        plt.savefig('init_u.png')

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -12,7 +12,6 @@ root_path = p.dirname(self_path)
 
 import sys
 sys.path.append(p.join(root_path, 'test'))
-<<<<<<< HEAD
 import output_preservation_test as opt
 
 
@@ -148,6 +147,8 @@ def write_f_plane_red_grav_init_u_input(nx,ny,layers):
         plt.pcolormesh(init_u)
         plt.colorbar()
         plt.savefig('init_u.png')
-=======
-import output_preservation_test as opt
->>>>>>> parent of 03580ac... functions to write inputs
+
+
+if __name__ == '__main__':
+    f_plane_red_grav_wind_test()
+    f_plane_red_grav_init_u_test()

--- a/test/physics_tests/f_plane_red_grav_init_u/.gitignore
+++ b/test/physics_tests/f_plane_red_grav_init_u/.gitignore
@@ -4,3 +4,4 @@ run_finished.txt
 layer thickness dropped below hmin.txt
 MIM
 MIM.f90
+*.png

--- a/test/physics_tests/f_plane_red_grav_init_u/.gitignore
+++ b/test/physics_tests/f_plane_red_grav_init_u/.gitignore
@@ -1,0 +1,6 @@
+input/
+output/
+run_finished.txt
+layer thickness dropped below hmin.txt
+MIM
+MIM.f90

--- a/test/physics_tests/f_plane_red_grav_init_u/parameters.in
+++ b/test/physics_tests/f_plane_red_grav_init_u/parameters.in
@@ -1,0 +1,79 @@
+! Parameter file. Change the values, but not the names.
+! 
+! Each namelist ends with a /
+! This is important and should not be deleted.
+!
+! au is viscosity
+! ah is thickness diffusivity
+! ar is linear drag between layers
+! dt is time step
+! slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
+! nTimeSteps: number of timesteps before stopping
+! dumpFreq: frequency of snapshot output
+! avFreq: frequency of averaged output
+! hmin: minimum layer thickness allowed by model (for stability)
+! maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
+! eps: convergence tolerance for SOR solver
+! freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+! g is the gravity at interfaces (including surface). must have as many entries as there are layers
+! input files are where to look for the various inputs
+!
+ &NUMERICS
+ au = 10.,
+ ah = 0.0,
+ ar = 1e-8,
+ dt = 600.,
+ slip = 0.0,
+ nTimeSteps = 8001,
+ dumpFreq = 30000,
+ avFreq = 3e6,
+ hmin = 100,
+ maxits = 1000,
+ eps = 1e-2,
+ freesurfFac = 0.,
+ thickness_error = 1e-2,
+ /
+ &MODEL
+ hmean = 400.,
+ depthFile = '',
+ H0 = 2000.,
+ RedGrav = .TRUE.,
+ /
+ &SPONGE
+ spongeHTimeScaleFile = '',
+ spongeUTimeScaleFile = '',
+ spongeVTimeScaleFile = '',
+ spongeHFile = '',
+ spongeUfile = '',
+ spongeVfile = '',
+ /
+ &PHYSICS
+ g_vec = 0.01,
+ rho0 = 1035.,
+ /
+ &GRID
+ nx = 100,
+ ny = 100,
+ layers = 1,
+ dx = 10e3,
+ dy = 10e3,
+ fUfile = 'input/fu.bin',
+ fVfile = 'input/fv.bin',
+ wetMaskFile = 'input/wetmask.bin',
+ /
+! Inital conditions for u, v, and h
+ &INITIAL_CONDITONS
+ initUfile = 'input/init_u.bin',
+ initVfile = '',
+ initHfile = 'input/initH.bin',
+ initEtaFile = '',
+ /
+ &EXTERNAL_FORCING
+ zonalWindFile = '',
+ meridionalWindFile = '', 
+ DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
+ /
+! input/initH.bin
+! 
+ &

--- a/test/physics_tests/f_plane_red_grav_wind/.gitignore
+++ b/test/physics_tests/f_plane_red_grav_wind/.gitignore
@@ -1,0 +1,7 @@
+input/
+output/
+run_finished.txt
+layer thickness dropped below hmin.txt
+MIM
+MIM.f90
+*.png

--- a/test/physics_tests/f_plane_red_grav_wind/parameters.in
+++ b/test/physics_tests/f_plane_red_grav_wind/parameters.in
@@ -1,0 +1,79 @@
+! Parameter file. Change the values, but not the names.
+! 
+! Each namelist ends with a /
+! This is important and should not be deleted.
+!
+! au is viscosity
+! ah is thickness diffusivity
+! ar is linear drag between layers
+! dt is time step
+! slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
+! nTimeSteps: number of timesteps before stopping
+! dumpFreq: frequency of snapshot output
+! avFreq: frequency of averaged output
+! hmin: minimum layer thickness allowed by model (for stability)
+! maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
+! eps: convergence tolerance for SOR solver
+! freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+! g is the gravity at interfaces (including surface). must have as many entries as there are layers
+! input files are where to look for the various inputs
+!
+ &NUMERICS
+ au = 10.,
+ ah = 0.0,
+ ar = 1e-8,
+ dt = 600.,
+ slip = 0.0,
+ nTimeSteps = 9001,
+ dumpFreq = 30000,
+ avFreq = 3e6,
+ hmin = 100,
+ maxits = 1000,
+ eps = 1e-2,
+ freesurfFac = 0.,
+ thickness_error = 1e-2,
+ /
+ &MODEL
+ hmean = 400.,
+ depthFile = '',
+ H0 = 2000.,
+ RedGrav = .TRUE.,
+ /
+ &SPONGE
+ spongeHTimeScaleFile = '',
+ spongeUTimeScaleFile = '',
+ spongeVTimeScaleFile = '',
+ spongeHFile = '',
+ spongeUfile = '',
+ spongeVfile = '',
+ /
+ &PHYSICS
+ g_vec = 0.01,
+ rho0 = 1035.,
+ /
+ &GRID
+ nx = 100,
+ ny = 100,
+ layers = 1,
+ dx = 10e3,
+ dy = 10e3,
+ fUfile = 'input/fu.bin',
+ fVfile = 'input/fv.bin',
+ wetMaskFile = 'input/wetmask.bin',
+ /
+! Inital conditions for u, v, and h
+ &INITIAL_CONDITONS
+ initUfile = '',
+ initVfile = '',
+ initHfile = 'input/initH.bin',
+ initEtaFile = '',
+ /
+ &EXTERNAL_FORCING
+ zonalWindFile = 'input/wind_x.bin',
+ meridionalWindFile = '', 
+ DumpWind = .FALSE.,
+ wind_mag_time_series_file = '',
+ /
+! input/initH.bin
+! 
+ &


### PR DESCRIPTION
Add a layerwise volume conservation test to the current test suite, as per #66.

The test requires volume to be conserved to better than one part in 100,000. For most of the tests this requirement is exceeded by several orders of magnitude.

Momentum and energy checks are proving more difficult, and will be added in a future pull request.