### PR TITLE
Pursuant to Issue #48, hack together basic hardware event counting for MIM runs.

### DIFF
--- a/benchmarks/profile.py
+++ b/benchmarks/profile.py
@@ -7,37 +7,43 @@ import sys
 sys.path.append(p.join(root_path, 'test'))
 import output_preservation_test as opt
 
-def do_red_grav(nx):
+def do_red_grav(nx, mim_build, perf):
     with opt.working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
         opt.run_experiment(
-            opt.write_input_beta_plane_bump_red_grav, nx, nx, 1, "MIM_prof")
+            opt.write_input_beta_plane_bump_red_grav, nx, nx, 1, mim_build, perf=perf)
 
-def do_n_layer(nx):
+def do_n_layer(nx, mim_build, perf):
     with opt.working_directory(p.join(self_path, "beta_plane_bump")):
         opt.run_experiment(
-            opt.write_input_beta_plane_bump, nx, nx, 2, "MIM_prof")
+            opt.write_input_beta_plane_bump, nx, nx, 2, mim_build, perf=perf)
 
 def main():
+    mim_build = "MIM_prof"
     nx = 100
     red_grav = True
+    perf = False
     for arg in sys.argv[1:]:
         if arg.lower() == "red-grav":
             red_grav = True
         elif arg.lower() == "n-layer":
             red_grav = False
+        elif arg.lower() == "perf":
+            perf = True
+            mim_build = "MIM"
         else:
             nx = int(arg)
     if red_grav:
         print "Profiling a reduced gravity configuration" \
             + " of size %dx%dx1 by 502 time steps." % (nx, nx)
-        do_red_grav(nx)
+        do_red_grav(nx, mim_build, perf)
         outpath = p.join(self_path, "beta_plane_bump_red_grav", "gmon.out")
     else:
         print "Profiling an n-layer configuration" \
             + " of size %dx%dx2 by 502 time steps." % (nx, nx)
-        do_n_layer(nx)
+        do_n_layer(nx, mim_build, perf)
         outpath = p.join(self_path, "beta_plane_bump", "gmon.out")
-    print "Inspect %s,\nfor example with gprof MIM_prof %s" % (outpath, outpath)
+    if not perf:
+        print "Inspect %s,\nfor example with gprof MIM_prof %s" % (outpath, outpath)
 
 if __name__ == '__main__':
     main()

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -41,7 +41,7 @@ def tweak_parameters(nx, ny, layers):
         "> parameters.new", shell=True)
     sub.check_call(["mv", "parameters.new", "parameters.in"])
 
-def run_experiment(write_input, nx, ny, layers, mim_exec=None, valgrind=False):
+def run_experiment(write_input, nx, ny, layers, mim_exec=None, valgrind=False, perf=False):
     if mim_exec is None:
         mim_exec = "MIM_test"
     sub.check_call(["rm", "-rf", "input/"])
@@ -54,7 +54,16 @@ def run_experiment(write_input, nx, ny, layers, mim_exec=None, valgrind=False):
     tweak_parameters(nx, ny, layers)
     then = time.time()
     if valgrind or 'MIM_TEST_VALGRIND_ALL' in os.environ:
+        assert not perf
         sub.check_call(["valgrind", "--error-exitcode=5", p.join(root_path, mim_exec)])
+    elif perf:
+        perf_cmds = ["perf", "stat", "-e", "r530010", # "flops", on my CPU.
+            "-e", "L1-dcache-loads", "-e", "L1-dcache-load-misses",
+            "-e", "L1-dcache-stores", "-e", "L1-dcache-store-misses",
+            "-e", "L1-icache-loads", "-e", "L1-icache-misses",
+            "-e", "L1-dcache-prefetches",
+            "-e", "branch-instructions", "-e", "branch-misses"]
+        sub.check_call(perf_cmds + [p.join(root_path, mim_exec)])
     else:
         sub.check_call([p.join(root_path, mim_exec)])
     run_time = time.time() - then


### PR DESCRIPTION
This is presumably OS-specific, in that, on the advice of
http://www.bnikolic.co.uk/blog/hpc-howto-measure-flops.html, it uses
`perf stat`, which relies on a Linux API for measuring CPU events.  On
Ubuntu, `perf` can be obtained by installing the `linux-tools-generic`
package.

That weird number 530010 is a hex code for "floating point operation"
for my particular CPU, which I discovered through the somewhat annoying
process of building `perfmon2/libpfm4` from source, per the instructions
on http://askubuntu.com/questions/637144/how-to-install-perfmon2-on-ubuntu,
and then running the resulting `showevtinfo` and `check_events` programs,
as advised in http://www.bnikolic.co.uk/blog/hpc-prof-events.html.